### PR TITLE
Fix(DSM-210):removed pagination spacing

### DIFF
--- a/malty/molecules/Pagination/Pagination.styled.ts
+++ b/malty/molecules/Pagination/Pagination.styled.ts
@@ -41,6 +41,11 @@ export const StyledContainer = styled.div<{ isWhite?: boolean }>`
       }
       margin-left: ${({ theme }) => theme.sizes['2xs'].value};
     }
+    .default-pagination {
+      button {
+        margin: 0;
+      }
+    }
   }
 `;
 

--- a/malty/molecules/Pagination/Pagination.tsx
+++ b/malty/molecules/Pagination/Pagination.tsx
@@ -150,7 +150,7 @@ export const Pagination = ({
             );
           }
           return (
-            <li key={pageNr}>
+            <li className="default-pagination" key={pageNr}>
               <Button
                 dataTestId={`${dataQaId}-page-${pageNr}`}
                 style={ButtonStyle.Transparent}


### PR DESCRIPTION
Added margin: 0 to enforce no margin. Safari was adding margins by default to pagination buttons