### PR TITLE
fix(DSM-272): fixed rounded corners in safari

### DIFF
--- a/malty/atoms/Input/Input.styled.ts
+++ b/malty/atoms/Input/Input.styled.ts
@@ -281,6 +281,7 @@ export const StyledSelect = styled.select<{
   text-align: center;
   appearance: none;
   position: relative;
+  border-radius: 0;
   &:disabled {
     color: ${({ theme }) => theme.colors.colours.system['disable-light-theme'].value};
     background-color: ${({ theme }) => theme.colors.colours.default.transparent.value};


### PR DESCRIPTION
fixed country code select in tel input. Safari by default was adding border-radius