### PR TITLE
fix(button): Inherit font properties from button definition

### DIFF
--- a/malty/atoms/Button/Button.styled.ts
+++ b/malty/atoms/Button/Button.styled.ts
@@ -64,6 +64,7 @@ const StyledButton = styled.button<{
     align-items: center;
     gap: ${({ theme }) => theme.sizes['2xs'].value};
     opacity: 1;
+    font: inherit;
     &.invisible {
       opacity: 0;
     }


### PR DESCRIPTION
# What

- Make direct child of button inherit all font properties defined in the parent component. (the button itself)

## Why

In some cases the consumer of malty might have a default value on reset files for instance that define a default `font-size` for all the `divs` and that will override the malty definition.

e.g

reset.css
```css
div {
  font-size: 16px
}
```

When someone uses the `Button` as it has a `div` before the final content, the `font~size` defined in the `Button` will not be applied. In the example below the `font-size` from the `ButtonStyle.Secondary` definition will be overwritten by the reset defition.

```typescript
<Button
 style={ButtonStyle.Secondary}
 ...
/>
````
