### PR TITLE
chore: bitmap datepicker

### DIFF
--- a/.bitmap
+++ b/.bitmap
@@ -1427,7 +1427,7 @@
     },
     "molecules/datepicker": {
         "scope": "carlsberggroup.malty",
-        "version": "0.0.17",
+        "version": "0.0.18",
         "mainFile": "index.ts",
         "rootDir": "malty/molecules/Datepicker"
     },


### PR DESCRIPTION
datepicker version bump