### PR TITLE
fix: Re-exports all types from `AlertBanner`

### DIFF
--- a/malty/molecules/AlertBanner/index.ts
+++ b/malty/molecules/AlertBanner/index.ts
@@ -1,3 +1,3 @@
 export { AlertBanner } from './AlertBanner';
 export { AlertBannerType } from './AlertBanner.types';
-export type { AlertBannerProps } from './AlertBanner.types';
+export type { AlertBannerI, AlertBannerProps, AnimatedProps } from './AlertBanner.types';


### PR DESCRIPTION
- Re-exported all types from AlertBanner in order to test if it fixes the following issue:

![image](https://user-images.githubusercontent.com/13966565/189398148-40e38084-12c0-48a0-80da-bdd57bee1cd0.png)
