### PR TITLE
fix(DSM-457): after animation message is not displayed correctly on safari

### DIFF
--- a/malty/atoms/Text/Text.styled.ts
+++ b/malty/atoms/Text/Text.styled.ts
@@ -7,6 +7,7 @@ export const StyledParagraph = styled.p<{
   align: TextAlign;
   italic: boolean;
 }>`
+  display: inline;
   font-family: inherit;
   margin: 0;
   padding: 0;


### PR DESCRIPTION
fix(DSM-457): after animation message is not displayed correctly on safari

**BUG** 👇

https://user-images.githubusercontent.com/18631683/199992087-2af31c32-5de6-41c5-aaf7-794ae0f7c86b.mov




**FIX** 👇


https://user-images.githubusercontent.com/18631683/199991439-bfa21b00-9a4e-4c1c-92ed-e6de4eed1441.mov

