### PR TITLE
feat(DSM-454): Add Icon name to data_testid attr

### DIFF
--- a/malty/atoms/Icon/Icon.tsx
+++ b/malty/atoms/Icon/Icon.tsx
@@ -13,6 +13,13 @@ export const Icon = ({
 }: IconProps) => {
   const IconElement = IconsPaths[name];
   return (
-    <IconElement viewBox={viewBox ?? '0 0 24 24'} className={className} color={color} size={size} onClick={onClick} />
+    <IconElement
+      viewBox={viewBox ?? '0 0 24 24'}
+      className={className}
+      color={color}
+      size={size}
+      onClick={onClick}
+      name={name}
+    />
   );
 };

--- a/malty/atoms/IconWrapper/IconWrapper.tsx
+++ b/malty/atoms/IconWrapper/IconWrapper.tsx
@@ -6,7 +6,7 @@ import { StyledIcon } from './IconWrapper.styled';
 import { IconColor, IconSize, IconWrapperProps } from './IconWrapper.types';
 
 const IconWrapper = (
-  { size = IconSize.Medium, color = IconColor.DigitalBlack, viewBox, className, onClick }: IconWrapperProps,
+  { size = IconSize.Medium, color = IconColor.DigitalBlack, viewBox, className, onClick, name }: IconWrapperProps,
   icon: JSX.Element
 ) => {
   const theme = useContext(ThemeContext) || defaultTheme;
@@ -20,7 +20,7 @@ const IconWrapper = (
       size={iconSize}
       onClick={onClick}
       theme={theme}
-      data-testid="svg-component"
+      data-testid={`icon-${name}`}
     >
       {icon}
     </StyledIcon>

--- a/malty/atoms/IconWrapper/IconWrapper.types.tsx
+++ b/malty/atoms/IconWrapper/IconWrapper.types.tsx
@@ -1,3 +1,4 @@
+import { IconName } from '@carlsberggroup/malty.atoms.icon';
 import { MouseEventHandler } from 'react';
 
 export interface IconWrapperProps extends React.HTMLAttributes<SVGElement> {
@@ -5,6 +6,7 @@ export interface IconWrapperProps extends React.HTMLAttributes<SVGElement> {
   size: IconSize;
   viewBox?: string;
   onClick?: MouseEventHandler<SVGElement>;
+  name: IconName;
 }
 
 export enum IconColor {


### PR DESCRIPTION
Before, the `data-testid` attribute for icons was hardcoded, making distinguishing icons harder.
Now, the same attribute contains the following dynamic string: `icon-<IconName>`.