### PR TITLE
chore: Test Ubuntu 20.04 workflow runner image

### DIFF
--- a/.github/workflows/bit.yml
+++ b/.github/workflows/bit.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   deploy:
     name: 'Deploy Bit Packages'
-    runs-on: public.ecr.aws/e5n7p9d7/bit:latest
+    runs-on: ubuntu-20.04
     env:
       BIT_TOKEN: ${{ secrets.BIT_TOKEN }}
     steps:


### PR DESCRIPTION
Testing if by changing the workflow image to be Ubuntu 20.04 it solves the current deployment issues.
`ubuntu-latest` recently changed from Ubuntu 20.04 to 22.04, so that might be the culprit given that nothing else supposedly changed.