### PR TITLE
test: fixed Icon component related tests

### DIFF
--- a/malty/atoms/Icon/Icon.test.tsx
+++ b/malty/atoms/Icon/Icon.test.tsx
@@ -7,17 +7,19 @@ import { IconName } from './Icon.types';
 
 describe('icon', () => {
   it('renders an icon as svg', () => {
+    const name = IconName.CarlsbergFilled;
     render(<Icon name={IconName.CarlsbergFilled} color={IconColor.Primary} size={IconSize.Small} />);
-    const element = screen.getByTestId('svg-component');
+    const element = screen.getByTestId(`icon-${name}`);
     expect(element).toBeInTheDocument();
   });
 
   it('calls function on click', () => {
+    const name = IconName.CarlsbergFilled;
     const iconMockClickFn = jest.fn();
     render(
       <Icon name={IconName.CarlsbergFilled} color={IconColor.Primary} onClick={iconMockClickFn} size={IconSize.Small} />
     );
-    fireEvent.click(screen.getByTestId('svg-component'));
+    fireEvent.click(screen.getByTestId(`icon-${name}`));
     expect(iconMockClickFn).toHaveBeenCalledTimes(1);
   });
 });

--- a/malty/atoms/IconWrapper/IconWrapper.tsx
+++ b/malty/atoms/IconWrapper/IconWrapper.tsx
@@ -20,7 +20,7 @@ const IconWrapper = (
       size={iconSize}
       onClick={onClick}
       theme={theme}
-      data-testid={`icon-${name}`}
+      data-testid={`icon-${name || 'component'}`}
     >
       {icon}
     </StyledIcon>

--- a/malty/atoms/IconWrapper/IconWrapper.types.tsx
+++ b/malty/atoms/IconWrapper/IconWrapper.types.tsx
@@ -6,7 +6,7 @@ export interface IconWrapperProps extends React.HTMLAttributes<SVGElement> {
   size: IconSize;
   viewBox?: string;
   onClick?: MouseEventHandler<SVGElement>;
-  name: IconName;
+  name?: IconName;
 }
 
 export enum IconColor {

--- a/malty/atoms/Input/Input.test.tsx
+++ b/malty/atoms/Input/Input.test.tsx
@@ -81,7 +81,7 @@ describe('input', () => {
       />
     );
 
-    const clearButton = screen.getByTestId('svg-component');
+    const clearButton = screen.getByTestId(`icon-ItemClose`);
     fireEvent.click(clearButton);
     expect(onClearButtonClick).toHaveBeenCalledTimes(1);
   });

--- a/malty/atoms/Pill/Pill.test.tsx
+++ b/malty/atoms/Pill/Pill.test.tsx
@@ -5,9 +5,10 @@ import React from 'react';
 import { Pill } from './Pill';
 
 describe('pill', () => {
+  const name = IconName.CarlsbergFilled;
   it('renders elements', () => {
     render(<Pill text="Pill text" icon={IconName.CarlsbergFilled} />);
     expect(screen.getByText('Pill text')).toBeInTheDocument();
-    expect(screen.getByTestId('svg-component')).toBeInTheDocument();
+    expect(screen.getByTestId(`icon-${name}`)).toBeInTheDocument();
   });
 });

--- a/malty/molecules/AlertBanner/AlertBanner.test.tsx
+++ b/malty/molecules/AlertBanner/AlertBanner.test.tsx
@@ -61,7 +61,7 @@ describe('<AlertBanner />', () => {
   });
   it('should render icon', () => {
     // Improvement: give a custom test id to svg element
-    const svg = screen.getAllByTestId('svg-component');
+    const svg = screen.getAllByTestId('icon-Close');
     expect(svg[0]).toBeDefined();
   });
   it('should render dismiss button', () => {

--- a/malty/molecules/Modal/Modal.test.tsx
+++ b/malty/molecules/Modal/Modal.test.tsx
@@ -52,7 +52,7 @@ describe('modal', () => {
       </>
     );
 
-    const closeIcon = screen.getAllByTestId('svg-component') && screen.getAllByTestId('svg-component')[0];
+    const closeIcon = screen.getAllByTestId('icon-component') && screen.getAllByTestId('icon-component')[0];
 
     fireEvent(
       closeIcon,

--- a/yarn.lock
+++ b/yarn.lock
@@ -9899,15 +9899,15 @@ __metadata:
   linkType: hard
 
 "cosmiconfig@npm:^7.0.0":
-  version: 7.0.1
-  resolution: "cosmiconfig@npm:7.0.1"
+  version: 7.1.0
+  resolution: "cosmiconfig@npm:7.1.0"
   dependencies:
     "@types/parse-json": ^4.0.0
     import-fresh: ^3.2.1
     parse-json: ^5.0.0
     path-type: ^4.0.0
     yaml: ^1.10.0
-  checksum: 4be63e7117955fd88333d7460e4c466a90f556df6ef34efd59034d2463484e339666c41f02b523d574a797ec61f4a91918c5b89a316db2ea2f834e0d2d09465b
+  checksum: c53bf7befc1591b2651a22414a5e786cd5f2eeaa87f3678a3d49d6069835a9d8d1aef223728e98aa8fec9a95bf831120d245096db12abe019fecb51f5696c96f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Some tests were failing due to the latest 'data-testId' changes to the Icon and IconWrapper components.