### PR TITLE
fix(MS-118): after animation the ellipsis has a different color from the text

### DIFF
--- a/malty/molecules/AlertBanner/AlertBanner.styled.ts
+++ b/malty/molecules/AlertBanner/AlertBanner.styled.ts
@@ -1,5 +1,4 @@
 import styled, { css, keyframes } from 'styled-components';
-import { TextColor } from '@carlsberggroup/malty.atoms.text';
 import { AlertBannerType } from './AlertBanner.types';
 
 const simpleFadeAnimation = keyframes`
@@ -28,7 +27,6 @@ export const Container = styled.div<{
     }
     return theme.colors.colours.system['notification-strong'].value;
   }};
-  color: ${({ theme }) => theme.colors.colours.default.white.value};
 `;
 
 export const FadeWrapper = styled.div<{
@@ -94,7 +92,6 @@ export const MessageContainer = styled.div<{
 export const StyledMessage = styled.div<{
   hideText: boolean;
   isMobile?: boolean;
-  color: TextColor;
 }>`
   overflow: hidden;
   display: flex;
@@ -103,7 +100,6 @@ export const StyledMessage = styled.div<{
   display: -webkit-box;
   -webkit-box-orient: vertical;
   transition: all 0.2s linear;
-  color: ${({ color, theme }) => (theme.colors ? theme.colors['text-colours'][color].value : TextColor.DigitalBlack)};
   ${({ hideText, isMobile }) => {
     if (hideText && isMobile) {
       return css`

--- a/malty/molecules/AlertBanner/AlertBanner.tsx
+++ b/malty/molecules/AlertBanner/AlertBanner.tsx
@@ -198,19 +198,14 @@ export const AlertBanner: FC<AlertBannerProps> = ({
   const renderMessage = () =>
     isMobile ? (
       <FadeText fire={triggerAnimation()} currentElementHeight={textWrapperSize}>
-        <StyledMessage
-          hideText={triggerAnimation()}
-          isMobile
-          ref={alertBannerStyledMessage}
-          color={textColorsMap[currentAlert.type]}
-        >
+        <StyledMessage hideText={triggerAnimation()} isMobile ref={alertBannerStyledMessage}>
           <Text textStyle={TextStyle.MediumSmallDefault} color={textColorsMap[currentAlert.type]}>
             {currentAlert.message}
           </Text>
         </StyledMessage>
       </FadeText>
     ) : (
-      <StyledMessage hideText={triggerAnimation()} color={textColorsMap[currentAlert.type]}>
+      <StyledMessage hideText={triggerAnimation()}>
         <Text textStyle={TextStyle.MediumSmallDefault} color={textColorsMap[currentAlert.type]}>
           {currentAlert.message}
         </Text>


### PR DESCRIPTION
fix(MS-118): after animation the ellipsis has a different color from the text


The StyledMessage color validation doesn't make sense, and the problem can be resolved by removing the color of the parent container.