### PR TITLE
ci: codeowners fix

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,2 @@
 *       @CarlsbergGBS/malty-maintainers
+*       @CarlsbergGBS/malty-contributors


### PR DESCRIPTION
Allow contributors to merge to main without maintainers.