### PR TITLE
feat(DSM-466): Remove circular dependecies on Icon

### DIFF
--- a/malty/atoms/IconWrapper/IconWrapper.types.tsx
+++ b/malty/atoms/IconWrapper/IconWrapper.types.tsx
@@ -1,4 +1,3 @@
-import { IconName } from '@carlsberggroup/malty.atoms.icon';
 import { MouseEventHandler } from 'react';
 
 export interface IconWrapperProps extends React.HTMLAttributes<SVGElement> {
@@ -6,7 +5,7 @@ export interface IconWrapperProps extends React.HTMLAttributes<SVGElement> {
   size: IconSize;
   viewBox?: string;
   onClick?: MouseEventHandler<SVGElement>;
-  name?: IconName;
+  name?: string;
 }
 
 export enum IconColor {


### PR DESCRIPTION
Proposed solution to remove the issue with circular dependencies between the `Icon` and `IconWrapper` components.