### PR TITLE
ci(approval): update github token

### DIFF
--- a/.github/workflows/approval.yml
+++ b/.github/workflows/approval.yml
@@ -20,13 +20,6 @@ jobs:
       startsWith(github.event.pull_request.head.ref, 'bugfix/') || 
       startsWith(github.event.pull_request.head.ref, 'hotfix/')
     steps:
-      - id: token
-        name: Authenticate
-        uses: getsentry/action-github-app-token@v1
-        with:
-          app_id: ${{ secrets.CARLSBERG_SECURITY_APP_ID }}
-          private_key: '${{ secrets.CARLSBERG_SECURITY_APP_PRIVATE_KEY }}'
-
       - id: check
         name: Check Reviewers
         uses: actions/github-script@v6
@@ -81,4 +74,4 @@ jobs:
             
             console.log("Got response from checks.create:", resp);
         env:
-          GITHUB_TOKEN: ${{ steps.token.outputs.token }}
+          GITHUB_TOKEN: ${{ secrets.CB_MALTY_APPROVAL_TOKEN }}


### PR DESCRIPTION
Replaces authentication using the security app with a Personal Access Token (owned by the organization) to bypass permissions issues.

An issue on DevOps board was created to further investigate the root issue (https://carlsberggbs.atlassian.net/browse/DEVOPS-2249).

Signed-off-by: João Cerqueira <joao.cerqueira@carlsberggroup.com>