### PR TITLE
ci(approval): replace env var with input

### DIFF
--- a/.github/workflows/approval.yml
+++ b/.github/workflows/approval.yml
@@ -20,11 +20,18 @@ jobs:
       startsWith(github.event.pull_request.head.ref, 'bugfix/') || 
       startsWith(github.event.pull_request.head.ref, 'hotfix/')
     steps:
+      - id: token
+        name: Authenticate
+        uses: getsentry/action-github-app-token@v1
+        with:
+          app_id: ${{ secrets.CARLSBERG_SECURITY_APP_ID }}
+          private_key: '${{ secrets.CARLSBERG_SECURITY_APP_PRIVATE_KEY }}'
+
       - id: check
         name: Check Reviewers
         uses: actions/github-script@v6
         with:
-          github-token: ${{ secrets.CB_MALTY_APPROVAL_TOKEN }}
+          github-token: ${{ steps.token.outputs.token }}
           script: |
             let conclusion = "failure";
 


### PR DESCRIPTION
Fixes the issues with the approval workflow. My guess is that GitHub stopped allowing modifying the `GITHUB_TOKEN` environment variable or propagating it down (for obv security reasons).

Fixed by using the `github-token` input that [actions/github-script](https://github.com/actions/github-script) provides already (and probably we should've been using since the beginning).

Closes [DEVOPS-2249](https://carlsberggbs.atlassian.net/browse/DEVOPS-2249)

Signed-off-by: João Cerqueira <joao.cerqueira@carlsberggroup.com>