### PR TITLE
fix(DSM-380): Fix Card image import in storybook

### DIFF
--- a/malty/atoms/Card/Card.stories.tsx
+++ b/malty/atoms/Card/Card.stories.tsx
@@ -1,5 +1,5 @@
 import { Headline, HeadlineStyle } from '@carlsberggroup/malty.atoms.headline';
-import { Image } from '@carlsberggroup/malty.atoms.image/Image';
+import { Image } from '@carlsberggroup/malty.atoms.image';
 import { Text, TextStyle } from '@carlsberggroup/malty.atoms.text';
 import { Story } from '@storybook/react';
 import React from 'react';


### PR DESCRIPTION
Quick fix for the Storybook file for an Image import, in the Card Component.