### PR TITLE
fix(DSM-380): Add storybook variant param to Card

### DIFF
--- a/malty/atoms/Card/Card.stories.tsx
+++ b/malty/atoms/Card/Card.stories.tsx
@@ -13,7 +13,8 @@ export default {
   parameters: {
     importObject: 'Card',
     importPath: '@carlsberggroup/malty.atoms.Card',
-    backgrounds: { name: 'dark background', value: '#000', default: true }
+    backgrounds: { name: 'dark background', value: '#000', default: true },
+    variants: ['shadowed', 'landscape', 'selected', 'onclick']
   },
   argTypes: {
     style: {


### PR DESCRIPTION
Adds Storybook `variant` query param in order to create a few examples in the Examples tab in ZeroHeight.