### PR TITLE
fix(DSM-520): updated prop as on Text

### DIFF
--- a/malty/atoms/Text/Text.tsx
+++ b/malty/atoms/Text/Text.tsx
@@ -18,14 +18,10 @@ export function Text({
 }: TextProps) {
   const theme = useContext(ThemeContext) || defaultTheme;
   let StyledTag = as;
+  const allowedTags = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p', 'span'];
 
-  switch (as) {
-    case 'span':
-      StyledTag = 'span';
-      break;
-    default:
-      StyledTag = 'p';
-      break;
+  if (as && allowedTags.includes(`${as}`)) {
+    StyledTag = as;
   }
 
   return (

--- a/malty/atoms/Text/Text.types.ts
+++ b/malty/atoms/Text/Text.types.ts
@@ -1,3 +1,5 @@
+import { ReactNode } from 'react';
+
 export interface TextProps extends React.HTMLAttributes<HTMLParagraphElement> {
   textStyle: TextStyle;
   align?: TextAlign;
@@ -6,7 +8,7 @@ export interface TextProps extends React.HTMLAttributes<HTMLParagraphElement> {
   as?: React.ElementType;
   ellipsis?: boolean;
   width?: string;
-  children: string | JSX.Element;
+  children: ReactNode;
   className?: string;
   dataQaId?: string;
 }

--- a/malty/atoms/Text/text.stories.tsx
+++ b/malty/atoms/Text/text.stories.tsx
@@ -75,13 +75,12 @@ export default {
       control: { type: 'text' }
     },
     as: {
-      table: {
-        disable: true
-      }
+      description: "HTML tag override to be used, from 'h1' through 'h6', as well as 'p' or 'span' tags.",
+      control: { type: 'text' }
     }
   }
 };
-const Template: Story<TextProps> = ({ textStyle, align, color, children, italic, ellipsis, width, className }) => (
+const Template: Story<TextProps> = ({ textStyle, align, color, children, italic, ellipsis, width, className, as }) => (
   <TextComponent
     align={align}
     color={color}
@@ -90,6 +89,7 @@ const Template: Story<TextProps> = ({ textStyle, align, color, children, italic,
     ellipsis={ellipsis}
     width={width}
     className={className}
+    as={as}
   >
     {children}
   </TextComponent>


### PR DESCRIPTION
updated prop `as` to be any element from 'h1' through 'h6', as well as 'p' or 'span' tags.