### PR TITLE
feat(DSM-551): Add word break to Headline

### DIFF
--- a/malty/atoms/Headline/Headline.styled.ts
+++ b/malty/atoms/Headline/Headline.styled.ts
@@ -72,4 +72,6 @@ export const StyledHeadline = styled.h1<{
       `}
     }
   `}
+  word-break: normal;
+  overflow-wrap: anywhere;
 `;


### PR DESCRIPTION
Adds css `word-break` to the Headline component so that the words break to a new line instead of overflowing.