### PR TITLE
feat(global): Remove `react/jsx-props-no-spreading` comments

### DIFF
--- a/malty/atoms/Button/Button.tsx
+++ b/malty/atoms/Button/Button.tsx
@@ -112,7 +112,6 @@ export function Button({
       tabIndex={tabIndex}
       className={selected ? `${className} active` : className}
       size={size}
-      // eslint-disable-next-line react/jsx-props-no-spreading
       {...props}
     >
       <div className="text-container">

--- a/malty/atoms/Label/Label.tsx
+++ b/malty/atoms/Label/Label.tsx
@@ -14,7 +14,6 @@ export function Label({ htmlFor, label, dataTestId, required, disabled, ...props
       htmlFor={htmlFor}
       required={required}
       disabled={disabled}
-      // eslint-disable-next-line react/jsx-props-no-spreading
       {...props}
     >
       {label}

--- a/malty/atoms/Radio/Radio.tsx
+++ b/malty/atoms/Radio/Radio.tsx
@@ -38,7 +38,6 @@ export function Radio({
           onChange={handleValueChange}
           disabled={disabled}
           required={required}
-          // eslint-disable-next-line react/jsx-props-no-spreading
           {...props}
         />
         <StyledLabel

--- a/malty/atoms/TextArea/TextArea.tsx
+++ b/malty/atoms/TextArea/TextArea.tsx
@@ -64,7 +64,6 @@ export function TextArea({
           readOnly={readOnly}
           maxLength={maxLength}
           required={required}
-          // eslint-disable-next-line react/jsx-props-no-spreading
           {...props}
         />
         <StyledTextAreaCharacterCounter disabled={disabled} theme={theme} data-testid={`${dataTestId}-counter`}>

--- a/malty/atoms/Toggle/Toggle.tsx
+++ b/malty/atoms/Toggle/Toggle.tsx
@@ -45,7 +45,6 @@ export function Toggle({
             checked={stateChecked}
             onChange={handleToggle}
             required={required}
-            // eslint-disable-next-line react/jsx-props-no-spreading
             {...props}
           />
           <StyledSwitch id={id} theme={theme} disabled={disabled} className="switch" />

--- a/malty/atoms/Tooltip/Tooltip.tsx
+++ b/malty/atoms/Tooltip/Tooltip.tsx
@@ -77,7 +77,6 @@ const Tooltip: TooltipType = function Tooltip({
       {triggerComponent(setReferenceElement)}
 
       <StyledTooltipWrapper
-        // eslint-disable-next-line react/jsx-props-no-spreading
         {...attributes.popper}
         ref={setPopperElement}
         style={styles.popper}

--- a/malty/molecules/Datepicker/Datepicker.tsx
+++ b/malty/molecules/Datepicker/Datepicker.tsx
@@ -213,7 +213,6 @@ export function Datepicker({
           dateFormatCalendar="MMMM"
           shouldCloseOnSelect={shouldCloseOnSelect}
           withPortal={withPortal}
-          // eslint-disable-next-line react/jsx-props-no-spreading
           {...props}
         >
           {renderDatepickerCaptions()}

--- a/malty/molecules/NavList/NavList.tsx
+++ b/malty/molecules/NavList/NavList.tsx
@@ -9,8 +9,6 @@ import { ItemProps, LinkComponentProps, NavItemProps, NavListProps, SubNavItemPr
 function LinkComponent({ component, href, children, componentProps }: LinkComponentProps) {
   const CustomComponent = (component as keyof JSX.IntrinsicElements) || null;
 
-  // we need to spread props in this case in order to allow custom properties being passed to the custom component
-  // eslint-disable-next-line react/jsx-props-no-spreading
   return component ? <CustomComponent {...componentProps}>{children}</CustomComponent> : <a href={href}>{children}</a>;
 }
 

--- a/malty/molecules/ProductsBar/ProductsBar.tsx
+++ b/malty/molecules/ProductsBar/ProductsBar.tsx
@@ -26,8 +26,6 @@ import { ProductsBarProps, ProfileMenuProps } from './ProductsBar.types';
 function LinkComponent({ component, href, children, componentProps }: LinkComponentProps) {
   const CustomComponent = (component as keyof JSX.IntrinsicElements) || null;
 
-  // we need to spread props in this case in order to allow custom properties being passed to the custom component
-  // eslint-disable-next-line react/jsx-props-no-spreading
   return component ? <CustomComponent {...componentProps}>{children}</CustomComponent> : <a href={href}>{children}</a>;
 }
 


### PR DESCRIPTION
# What
In my previous [PR](https://github.com/CarlsbergGBS/cx-component-library/pull/551) I added `react/jsx-props-no-spreading` part of the general eslint rules to be off for the whole project, in our case (Malty) makes more sense because we are going to be sharing a bunch of props between components and even native components, so in this PR I removed all the inline `react/jsx-props-no-spreading` comments from the component files

## Code Quality Checklist
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have updated storybook (if appropriate)

## Jira card
Not Applicable