### PR TITLE
fix(ProductCard): Index exports

### DIFF
--- a/malty/molecules/ProductCard/index.ts
+++ b/malty/molecules/ProductCard/index.ts
@@ -1,3 +1,2 @@
-export { Card } from './ProductCard';
-export { CardOrientation, CardStyle } from './ProductCard.types';
-export type { CardProps } from './ProductCard.types';
+export { ProductCard } from './ProductCard';
+export type { ProductCardProps } from './ProductCard.types';


### PR DESCRIPTION
# What

<!-- Describe the technical "why" behind your changes -->
We are getting these errors while trying to merge the Product card branch to the main
![image](https://user-images.githubusercontent.com/58294069/224338006-9efb6466-6b02-4f23-b6fd-f9d3991a9350.png)

this is because we had the wrong exports on the ProductCard index
https://github.com/CarlsbergGBS/cx-component-library/pull/548/files#diff-a11133b05778a09ac8633dd258651182993502926b79aa4b8a74aa9970c8e542R1-R3

This is the PR to fix and use the proper ones

## Code Quality Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have updated storybook (if appropriate)

## Jira Card

<!-- if no card is associated, remove the line bellow and add "Not Applicable" -->

Not Applicable
