### PR TITLE
fix(Input): [DSM-566] Add optional name prop to enable browser autocomplete

### DIFF
--- a/malty/atoms/Input/Input.stories.tsx
+++ b/malty/atoms/Input/Input.stories.tsx
@@ -150,6 +150,10 @@ export default {
     disableQuantityInput: {
       control: 'boolean',
       description: 'Input Quantity, disabled'
+    },
+    name: {
+      control: 'text',
+      description: `HTML name attribute for the input, useful if you're trying to enable browser native autocomplete`
     }
   }
 } as Meta;
@@ -174,7 +178,8 @@ const Template: Story<InputProps> = ({
   required,
   disableQuantityInput,
   max,
-  min
+  min,
+  name
 }: InputProps) => {
   const [stateValue, setStateValue] = useState(value);
   return (
@@ -190,7 +195,7 @@ const Template: Story<InputProps> = ({
       iconPosition={iconPosition}
       clearable={clearable}
       mask={mask}
-      onValueChange={(newValue: string) => setStateValue(newValue)}
+      onValueChange={setStateValue}
       hint={hint}
       dataTestId={dataTestId}
       readOnly={readOnly}
@@ -200,6 +205,7 @@ const Template: Story<InputProps> = ({
       disableQuantityInput={disableQuantityInput}
       max={max}
       min={min}
+      name={name}
     />
   );
 };

--- a/malty/atoms/Input/Input.tsx
+++ b/malty/atoms/Input/Input.tsx
@@ -56,12 +56,14 @@ export const Input = forwardRef(
       onClickRightInputButton,
       min,
       max,
+      name: nameProp,
       ...props
     }: InputProps,
     ref: React.Ref<HTMLInputElement>
   ) => {
     const theme = useContext(ThemeContext) || defaultTheme;
     const id = useMemo(() => uuid(), []);
+    const name = nameProp || id;
     const inputSize = useInputSize({ size });
     const [passwordToggleType, setPasswordToggleType] = useState(InputType.Password);
 
@@ -140,7 +142,7 @@ export const Input = forwardRef(
       <StyledClearableWrapper>
         <StyledInput
           data-testid={dataTestId}
-          name={id}
+          name={name}
           id={id}
           value={value}
           placeholder={placeholder}
@@ -194,7 +196,7 @@ export const Input = forwardRef(
           disableQuantityInput={disableQuantityInput}
           className="quanity-input"
           data-testid={dataTestId}
-          name={id}
+          name={name}
           id={id}
           value={value}
           placeholder="0"
@@ -271,7 +273,7 @@ export const Input = forwardRef(
           </StyledSelect>
           <StyledInput
             data-testid={dataTestId}
-            name={id}
+            name={name}
             id={id}
             value={value}
             placeholder={placeholder}

--- a/malty/atoms/Input/Input.types.ts
+++ b/malty/atoms/Input/Input.types.ts
@@ -30,6 +30,7 @@ export interface InputProps extends React.HTMLAttributes<HTMLInputElement> {
   pattern?: string;
   min?: number;
   max?: number;
+  name?: string;
 }
 
 export interface UseInputSizeProps {


### PR DESCRIPTION
# What

With the previous implementation we were opting-out the native browser autocomplete experience of some fields because the generated name for the input is a `uuid`, the ideia now is to give the consumers of malty the possibility to pass a custom name to enable the autocompletion, and as a fallback for when the `name` is not provided the previous `uuid` will continue to be used.

## Code Quality Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have updated storybook (if appropriate)

## Jira Card

<!-- if no card is associated, remove the line bellow and add "Not Applicable" -->

DSM-566
