### PR TITLE
feat(Card): [DSM-517] Add disabled prop

### DIFF
--- a/malty/atoms/Card/Card.stories.tsx
+++ b/malty/atoms/Card/Card.stories.tsx
@@ -50,6 +50,10 @@ export default {
       table: {
         category: 'Events'
       }
+    },
+    disabled: {
+      control: 'boolean',
+      description: 'Makes the card disabled'
     }
   }
 };

--- a/malty/atoms/Card/Card.styled.ts
+++ b/malty/atoms/Card/Card.styled.ts
@@ -6,6 +6,7 @@ export const StyledCardContainer = styled.div<{
   selected: boolean;
   cardStyle: CardStyle;
   hover: boolean;
+  disabled?: boolean;
 }>`
   display: flex;
   align-items: stretch;
@@ -69,20 +70,28 @@ export const StyledCardContainer = styled.div<{
     `}
 
   ${({ theme, selected }) =>
-    theme &&
     selected &&
     css`
       border: ${theme.borders['border-3px--solid']['border-width'].value}
         ${theme.borders['border-3px--solid']['border-style'].value} ${theme.colors.theme.themePrimary.value};
+    `};
+
+  ${({ theme, disabled }) =>
+    disabled &&
+    css`
+      border-color: ${theme.colors.colours.system['disable-light-theme'].value};
     `}
 `;
 
 export const StyledCardHero = styled.div<{
   orientation: CardOrientation;
+  disabled?: boolean;
 }>`
   display: flex;
   align-items: stretch;
   position: relative;
+  opacity: ${({ disabled }) => (disabled ? 0.5 : 'initial')};
+
   ${({ orientation }) => {
     if (orientation === CardOrientation.Landscape) {
       return css`
@@ -99,6 +108,7 @@ export const StyledCardHero = styled.div<{
     `;
   }};
 `;
+
 export const StyledCardBody = styled.div<{
   orientation: CardOrientation;
 }>`

--- a/malty/atoms/Card/Card.test.tsx
+++ b/malty/atoms/Card/Card.test.tsx
@@ -1,5 +1,6 @@
 import { render } from '@carlsberggroup/malty.utils.test';
-import { fireEvent, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { Card } from './Card';
 import { CardOrientation, CardStyle } from './Card.types';
@@ -44,8 +45,28 @@ describe('Card', () => {
         onClick={onClick}
       />
     );
-    fireEvent.click(screen.getByTestId('card-element'));
-    fireEvent.click(screen.getByText(titleText));
+    userEvent.click(screen.getByTestId('card-element'));
+    userEvent.click(screen.getByText(titleText));
     expect(onClick).toHaveBeenCalledTimes(2);
+  });
+
+  it('disables onClick function when is disabled', () => {
+    const onClick = jest.fn();
+    render(
+      <Card
+        dataTestId="card-element"
+        selected={false}
+        cardHero={defaultHero}
+        cardBody={defaultBody}
+        cardStyle={CardStyle.Plain}
+        orientation={CardOrientation.Portrait}
+        onClick={onClick}
+        disabled
+      />
+    );
+
+    userEvent.click(screen.getByTestId('card-element'));
+    userEvent.click(screen.getByText(titleText));
+    expect(onClick).not.toHaveBeenCalled();
   });
 });

--- a/malty/atoms/Card/Card.tsx
+++ b/malty/atoms/Card/Card.tsx
@@ -11,7 +11,8 @@ export const Card = ({
   cardHero,
   cardBody,
   onClick,
-  dataTestId = 'card-element'
+  dataTestId = 'card-element',
+  disabled
 }: CardProps) => {
   const theme = useContext(ThemeContext) || defaultTheme;
 
@@ -20,13 +21,14 @@ export const Card = ({
       orientation={orientation}
       selected={selected}
       cardStyle={cardStyle}
-      onClick={onClick}
-      hover={!!onClick}
+      {...(!disabled && { onClick })}
+      hover={!disabled && !!onClick}
       theme={theme}
       data-testid={dataTestId}
+      disabled={disabled}
     >
       {cardHero && (
-        <StyledCardHero orientation={orientation} theme={theme} data-testid={`${dataTestId}-hero`}>
+        <StyledCardHero orientation={orientation} theme={theme} data-testid={`${dataTestId}-hero`} disabled={disabled}>
           {cardHero}
         </StyledCardHero>
       )}

--- a/malty/atoms/Card/Card.types.ts
+++ b/malty/atoms/Card/Card.types.ts
@@ -6,6 +6,7 @@ export interface CardProps {
   cardBody?: React.ReactNode | JSX.Element;
   onClick?: React.MouseEventHandler<HTMLDivElement>;
   dataTestId?: string;
+  disabled?: boolean;
 }
 
 export enum CardStyle {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4223,9 +4223,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/styled-components@npm:^5.1.26":
+"@types/styled-components@npm:>=5.1.26 <6.0.0":
   version: 5.1.26
-  resolution: "@types/styled-components@npm:5.1.26"
+  resolution: "@types/styled-components@npm:5.1.26::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Fstyled-components%2F-%2Fstyled-components-5.1.26.tgz"
   dependencies:
     "@types/hoist-non-react-statics": "*"
     "@types/react": "*"
@@ -4282,9 +4282,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/uuid@npm:^9.0.0":
+"@types/uuid@npm:>=9.0.0 <10.0.0":
   version: 9.0.1
-  resolution: "@types/uuid@npm:9.0.1"
+  resolution: "@types/uuid@npm:9.0.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Fuuid%2F-%2Fuuid-9.0.1.tgz"
   checksum: c472b8a77cbeded4bc529220b8611afa39bd64677f507838f8083d8aac8033b1f88cb9ddaa2f8589e0dcd2317291d0f6e1379f82d5ceebd6f74f3b4825288e00
   languageName: node
   linkType: hard
@@ -9344,9 +9344,9 @@ __metadata:
     "@types/react-dom": ">=17.0.5 <18.0.0"
     "@types/react-table": ^7.7.12
     "@types/react-test-renderer": ^17.0.2
-    "@types/styled-components": ^5.1.26
+    "@types/styled-components": ">=5.1.26 <6.0.0"
     "@types/testing-library__jest-dom": 5.9.5
-    "@types/uuid": ^9.0.0
+    "@types/uuid": ">=9.0.0 <10.0.0"
     "@typescript-eslint/eslint-plugin": ^5.54.0
     "@typescript-eslint/parser": ^5.53.0
     babel-jest: ^29.4.1
@@ -19561,6 +19561,8 @@ __metadata:
 "test-fd7b7f@workspace:malty/utils/test":
   version: 0.0.0-use.local
   resolution: "test-fd7b7f@workspace:malty/utils/test"
+  dependencies:
+    "@types/react": ^18.0.28
   peerDependencies:
     react: ^17.0.2
   languageName: unknown


### PR DESCRIPTION
# What

<!-- Describe the technical "why" behind your changes -->
For this task we wanted to add the option to pass the disabled prop, this will make these changes:
- Disables onClick event function
- The image in cardHero has 50% opacity
- The selection stroke should have the color disable-light-theme

**Notes**
Just to keep in mind, we are not taking care of the theme in the cardBody, this means that we are not adding the opacity as 50% since the body should be made by Malty components such as buttons and the user is the one adding the disabled prop to those components as well

## Code Quality Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)
- [x] I have updated storybook (if appropriate)

## Jira Card

<!-- if no card is associated, remove the line bellow and add "Not Applicable" -->

DSM-517
