### PR TITLE
fix(datepicker): [DSM-572] Add readonly on input when selectsRange

### DIFF
--- a/malty/molecules/Datepicker/Datepicker.stories.tsx
+++ b/malty/molecules/Datepicker/Datepicker.stories.tsx
@@ -73,8 +73,7 @@ export default {
       description: 'readOnly datepicker'
     },
     selectsRange: {
-      description:
-        "enable date range selection. This will set the input as readonly since the library doesn't provide a proper way to edit dates from the input directly",
+      description: 'enable date range selection. This will set the input as readonly',
       control: {
         type: 'boolean'
       }

--- a/malty/molecules/Datepicker/Datepicker.tsx
+++ b/malty/molecules/Datepicker/Datepicker.tsx
@@ -21,6 +21,8 @@ import {
 } from './Datepicker.styled';
 import { Colors, DatepickerProps, DatepickerSize } from './Datepicker.types';
 
+const DATE_PICKER_INPUT_CLASSNAME = 'datepickerInput';
+
 export const Container: FC<{ withoutBorder?: boolean }> = ({ children, withoutBorder }) => {
   const theme = useContext(ThemeContext) || defaultTheme;
 
@@ -118,9 +120,12 @@ export const Datepicker = ({
     }
   }, [size, theme]);
 
+  // This will set the input as readonly since the library doesn't provide a proper way to edit dates from the input directly ATM",
   useEffect(() => {
     if (selectsRange && datepickerRef.current) {
-      const inputElement = datepickerRef.current.querySelector('.datepickerInput') as HTMLInputElement | undefined;
+      const inputElement = datepickerRef.current.querySelector(`.${DATE_PICKER_INPUT_CLASSNAME}`) as
+        | HTMLInputElement
+        | undefined;
       if (inputElement) {
         inputElement.readOnly = true;
       }
@@ -218,7 +223,7 @@ export const Datepicker = ({
           minDate={minDate}
           maxDate={maxDate}
           excludeDates={excludeDates}
-          className="datepickerInput"
+          className={DATE_PICKER_INPUT_CLASSNAME}
           inline={inline}
           selectsRange={selectsRange}
           placeholderText={placeholderText}


### PR DESCRIPTION
# What

<!-- Describe the technical "why" behind your changes -->
We had a problem when the **selectsRange** was present, the react-datepicker library doesn't provide a proper way to edit the date from the input directly. We tried several approaches but since we are using this library we couldn't make it work.

The **selectsRange** was introduced in v4.0.0 and since then this behaviour has not been provided, if in the future changes we will use it. You can follow this issue, is still open at this moment https://github.com/Hacker0x01/react-datepicker/issues/3906

For now what we did was putting readonly on the input if **selectsRange** is present

## Code Quality Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have updated storybook (if appropriate)

## Jira Card

<!-- if no card is associated, remove the line bellow and add "Not Applicable" -->

DSM-572
