### PR TITLE
fix(hero): [DSM-614] Align buttons to the left in mobile

### DIFF
--- a/malty/atoms/Hero/Hero.styled.ts
+++ b/malty/atoms/Hero/Hero.styled.ts
@@ -138,6 +138,6 @@ export const StyledButtonsWrapper = styled.div`
   display: flex;
   @media (max-width: ${({ theme }) => theme.layout.xsmall['device-max-width']?.value}) {
     flex-direction: column;
-    align-items: left;
+    align-items: flex-start;
   }
 `;


### PR DESCRIPTION
# What

<!-- Describe the technical "why" behind your changes -->
This is a small fix to align the buttons to the left when mobile

## Code Quality Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have updated storybook (if appropriate)

## Jira Card

<!-- if no card is associated, remove the line bellow and add "Not Applicable" -->

DSM-614
