### PR TITLE
fix(input): Quantity readonly styles when min 0

### DIFF
--- a/malty/atoms/Input/Input.styled.ts
+++ b/malty/atoms/Input/Input.styled.ts
@@ -230,6 +230,7 @@ export const StyledButton = styled.button<{
   size?: string;
   isError?: boolean;
   readOnly?: boolean;
+  disabled?: boolean;
 }>`
   cursor: pointer;
   height: ${({ size }) => size}px;


### PR DESCRIPTION
# What

<!-- Describe the technical "why" behind your changes -->
The readonly styles were not being applied on the input quantity buttons because it was using the disabled styles instead.

## Code Quality Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have updated storybook (if appropriate)

## Jira Card

<!-- if no card is associated, remove the line bellow and add "Not Applicable" -->

Not Applicable
