### PR TITLE
fix(accordion): [DSM-647] remove padding start from accordion component

### DIFF
--- a/malty/molecules/Accordion/Accordion.styled.ts
+++ b/malty/molecules/Accordion/Accordion.styled.ts
@@ -5,6 +5,8 @@ import { AccordionColor } from '.';
 export const StyledAccordionWrapper = styled.ul<{
   variant?: AccordionColor;
 }>`
+  padding-inline-start: 0;
+
   li {
     ${({ variant, theme }) =>
       css`


### PR DESCRIPTION
# What

<!-- Describe the technical "why" behind your changes -->
Remove default padding inline start from the _ul_ element in the accordion component.

## Code Quality Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have updated storybook (if appropriate)

## Jira Card

<!-- if no card is associated, remove the line bellow and add "Not Applicable" -->

DSM-647
