### PR TITLE
feat(product-card, product-quantity-actions): [DSM-785] readonly option

### DIFF
--- a/malty/atoms/Input/Input.tsx
+++ b/malty/atoms/Input/Input.tsx
@@ -91,27 +91,31 @@ export const Input = forwardRef(
     };
 
     const handleClear = () => {
-      onValueChange('');
+      onValueChange?.('');
       onClearButtonClick?.();
     };
 
     const handleLeftButtonClick = () => {
-      onValueChange(value ? (+value - 1).toString() : '-1');
+      onValueChange?.(value ? (+value - 1).toString() : '-1');
       onClickLeftInputButton?.();
     };
 
     const handleRightButtonClick = () => {
-      onValueChange(value ? (+value + 1).toString() : '1');
+      onValueChange?.(value ? (+value + 1).toString() : '1');
       onClickRightInputButton?.();
     };
 
     const handleOnQuantityChange = ({ currentTarget: { value: currentValue } }: ChangeEvent<HTMLInputElement>) => {
       if (currentValue === '') {
-        onValueChange(currentValue);
+        onValueChange?.(currentValue);
       } else {
         const newValue = parseInt(currentValue, 10);
-        onValueChange(ensureQuantityRange(newValue, min, max).toString());
+        onValueChange?.(ensureQuantityRange(newValue, min, max).toString());
       }
+    };
+
+    const handleOnInputChange = (event: ChangeEvent<HTMLInputElement>) => {
+      onValueChange?.(transform((event.target as HTMLInputElement).value));
     };
 
     const renderClearable = () =>
@@ -165,7 +169,7 @@ export const Input = forwardRef(
           addRight={
             (iconPosition !== InputIconPosition.Left && type !== InputType.Quantity) || type === InputType.Password
           }
-          onChange={(e) => onValueChange(transform((e.target as HTMLInputElement).value))}
+          onChange={handleOnInputChange}
           onBlur={(e) => onInputBlur?.(transform((e.target as HTMLInputElement).value))}
           type={type === InputType.Password ? passwordToggleType : type}
           theme={theme}
@@ -294,7 +298,7 @@ export const Input = forwardRef(
             isError={!!error}
             isIconLeft={iconPosition === InputIconPosition.Left}
             addRight={iconPosition !== InputIconPosition.Left && type !== InputType.Quantity}
-            onChange={(e) => onValueChange(transform((e.target as HTMLInputElement).value))}
+            onChange={handleOnInputChange}
             onBlur={(e) => onInputBlur?.(transform((e.target as HTMLInputElement).value))}
             type={type}
             theme={theme}

--- a/malty/atoms/Input/Input.types.ts
+++ b/malty/atoms/Input/Input.types.ts
@@ -3,7 +3,7 @@ import { IconName } from '@carlsberggroup/malty.atoms.icon';
 export interface InputProps extends React.HTMLAttributes<HTMLInputElement> {
   value: string;
   label?: string;
-  onValueChange: (value: string) => void;
+  onValueChange?: (value: string) => void;
   onInputBlur?: (value: string) => void;
   type: InputType;
   placeholder?: string;

--- a/malty/molecules/ProductCard/ProductCard.stories.tsx
+++ b/malty/molecules/ProductCard/ProductCard.stories.tsx
@@ -12,13 +12,18 @@ import React, { useState } from 'react';
 import { ProductCard as ProductCardComponent } from './ProductCard';
 import { ProductCardProps } from './ProductCard.types';
 
+enum ProductCardVariants {
+  Landscape = 'landscape',
+  ReadOnly = 'readOnly'
+}
+
 export default {
   title: 'Cards/ProductCard',
   component: ProductCardComponent,
   parameters: {
     importObject: 'ProductCard',
     importPath: '@carlsberggroup/malty.molecules.product-card',
-    variants: ['default', 'landscape']
+    variants: Object.values(ProductCardVariants)
   },
   argTypes: {
     title: {
@@ -246,7 +251,7 @@ const params = new URLSearchParams(window.location.search);
 const variant = params.get('variant');
 
 switch (variant) {
-  case 'landscape':
+  case ProductCardVariants.Landscape:
     ProductCard.args = {
       title: 'This is an article card Title',
       imageSrc: 'https://picsum.photos/320/180',
@@ -281,6 +286,26 @@ switch (variant) {
         { message: 'Max order limit reached', color: AlertInlineColor.NotificationLight, firstActionText: 'Edit' },
         { message: 'Max order limit: 5', color: AlertInlineColor.NotificationLight }
       ]
+    };
+    break;
+  case ProductCardVariants.ReadOnly:
+    ProductCard.args = {
+      title: 'This is an article card Title',
+      imageSrc: 'https://picsum.photos/320/180',
+      dataTestId: 'Product-card',
+      actionQuantityInput: {
+        value: '3',
+        readOnly: true
+      },
+      price: { base: '₭ 99,800.00', discount: '₭ 86,000.00' },
+      sku: 'Sku: 12512 512',
+      loyalty: { label: '+30', imageSrc: 'https://www.carlsberg.com/media/2249/favicon-32x32.png' },
+      stock: { label: 'In Stock', stockColor: TextColor.Success },
+      quantitySelectOptions: selectQuanityOptions,
+      discountPill: { text: '20%', color: PillColor.AlertStrong },
+      promoPill: { text: 'Promo', color: PillColor.AlertStrong, icon: IconName.Coupon },
+      cartPill: { text: '2', color: PillColor.Success, icon: IconName.Cart },
+      favoriteIconColor: IconColor.Primary
     };
     break;
 

--- a/malty/molecules/ProductCard/ProductCard.test.tsx
+++ b/malty/molecules/ProductCard/ProductCard.test.tsx
@@ -23,13 +23,13 @@ const defaultBody = (
 );
 
 describe('ProductCard', () => {
-  it('renders with correct content', () => {
+  it('should render with correct content', () => {
     render(<ProductCard imageSrc={heroScr} title={titleText} sku={sku} actionButton={actionButton} />);
     expect(screen.getByText(titleText)).not.toBeNull();
     expect(screen.getByText(sku)).not.toBeNull();
   });
 
-  it('calls function on click', () => {
+  it('should call function on click', () => {
     const onClick = jest.fn();
     render(
       <ProductCard

--- a/malty/molecules/ProductCard/ProductCard.tsx
+++ b/malty/molecules/ProductCard/ProductCard.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/jsx-props-no-spreading */
 import { Card, CardOrientation, CardStyle } from '@carlsberggroup/malty.atoms.card';
 import { Icon, IconColor, IconName, IconSize } from '@carlsberggroup/malty.atoms.icon';
 import { Image } from '@carlsberggroup/malty.atoms.image';
@@ -73,6 +72,7 @@ export const ProductCard = ({
       window.removeEventListener('resize', handleWindowSizeChange);
     };
   }, []);
+
   return (
     <Card
       dataTestId={dataTestId}

--- a/malty/molecules/ProductCard/ProductCard.types.ts
+++ b/malty/molecules/ProductCard/ProductCard.types.ts
@@ -33,5 +33,5 @@ export interface ProductCardProps {
   imageHeight?: string;
   imageWidth?: string;
   actionQuantityInput?: ActionQuantityInput;
-  actionButton: ActionButton;
+  actionButton?: ActionButton;
 }

--- a/malty/molecules/ProductQuantityActions/ProductQuantityActions.styled.ts
+++ b/malty/molecules/ProductQuantityActions/ProductQuantityActions.styled.ts
@@ -1,3 +1,4 @@
+import { Input } from '@carlsberggroup/malty.atoms.input';
 import { TextColor } from '@carlsberggroup/malty.atoms.text';
 import styled from 'styled-components';
 
@@ -15,6 +16,10 @@ export const StyledStockStatusColor = styled.div<{
   height: ${({ theme }) => theme.sizes['3xs'].value};
   background-color: ${({ theme, infoColor }) => infoColor && theme.colors['text-colours'][infoColor].value};
   border-radius: 50%;
+`;
+
+export const StyledReadOnlyInput = styled(Input)`
+  max-width: 50%;
 `;
 
 export const StyledActions = styled.div`

--- a/malty/molecules/ProductQuantityActions/ProductQuantityActions.test.tsx
+++ b/malty/molecules/ProductQuantityActions/ProductQuantityActions.test.tsx
@@ -18,9 +18,10 @@ const actionQuantityInput: ActionQuantityInput = {
   value: '2',
   onValueChange: jest.fn()
 };
+const dataTestId = 'product-quantity-input';
 
 describe('ProductQuantityActions', () => {
-  test('renders with correct content', () => {
+  it('should render with correct content', () => {
     render(
       <ProductQuantityActions actionButton={actionButton} actionQuantityInput={actionQuantityInput} stock={stock} />
     );
@@ -32,44 +33,37 @@ describe('ProductQuantityActions', () => {
     expect(screen.getByText('Add to cart')).toBeInTheDocument();
   });
 
-  test('renders correctly if no optional prop is passed', () => {
+  it('should render correctly if no optional prop is passed', () => {
     render(<ProductQuantityActions actionButton={actionButton} />);
 
     expect(screen.queryByText('In Stock')).not.toBeInTheDocument();
-
     // TODO: check if we can get rid of this fallback
     expect(screen.getByText(actionButton.text ?? '')).toBeInTheDocument();
   });
 
-  test('calls onInputQuantityChange correctly', () => {
+  it('should call onInputQuantityChange correctly', () => {
     render(<ProductQuantityActions actionButton={actionButton} actionQuantityInput={actionQuantityInput} />);
 
     const increaseButton = screen.getByTestId('default-quantity-plus');
+
     userEvent.click(increaseButton);
+
     expect(actionQuantityInput.onValueChange).toHaveBeenCalledTimes(1);
   });
 
-  test('renders with correct content when button is disabled', () => {
+  it('should render with correct content when button is disabled', () => {
     render(<ProductQuantityActions actionButton={{ ...actionButton, disabled: true }} />);
+
     expect(screen.getByTestId('default-button')).toBeDisabled();
   });
 
-  test('renders with correct content when button is loading', () => {
+  it('should render with correct content when button is loading', () => {
     render(<ProductQuantityActions actionButton={{ ...actionButton, loading: true }} />);
+
     expect(screen.getByTestId('default-button-loading')).toBeInTheDocument();
   });
 
-  test('renders with correct content when input quantity is readonly', () => {
-    render(
-      <ProductQuantityActions
-        actionButton={actionButton}
-        actionQuantityInput={{ ...actionQuantityInput, readOnly: true }}
-      />
-    );
-    expect(screen.getByTestId('default')).toHaveAttribute('readonly');
-  });
-
-  test('renders correctly when input quantity min and max is set', () => {
+  it('should render correctly when input quantity min and max is set', () => {
     const ProductQuantityActionsControlled = () => {
       const [value, setValue] = React.useState('0');
       return (
@@ -88,19 +82,27 @@ describe('ProductQuantityActions', () => {
     expect(screen.getByDisplayValue('0')).toBeInTheDocument();
     expect(increaseButton).toBeEnabled();
     expect(decreaseButton).toBeDisabled();
+
     userEvent.click(decreaseButton);
+
     expect(screen.getByDisplayValue('0')).toBeInTheDocument();
+
     userEvent.click(increaseButton);
+
     expect(screen.getByDisplayValue('1')).toBeInTheDocument();
     expect(increaseButton).toBeDisabled();
     expect(decreaseButton).toBeEnabled();
+
     userEvent.click(increaseButton);
+
     expect(screen.getByDisplayValue('1')).toBeInTheDocument();
+
     userEvent.click(decreaseButton);
+
     expect(screen.getByDisplayValue('0')).toBeInTheDocument();
   });
 
-  test('renders correctly when value is changed after initial render', () => {
+  it('should render correctly when value is changed after initial render', () => {
     const { rerender } = render(
       <ProductQuantityActions actionButton={actionButton} actionQuantityInput={actionQuantityInput} />
     );
@@ -116,5 +118,57 @@ describe('ProductQuantityActions', () => {
 
     expect(screen.queryByDisplayValue(actionQuantityInput.value)).not.toBeInTheDocument();
     expect(screen.getByDisplayValue('10')).toBeInTheDocument();
+  });
+
+  it('should not display signs when readOnly', () => {
+    render(
+      <ProductQuantityActions
+        actionQuantityInput={{ ...actionQuantityInput, readOnly: true }}
+        dataTestId={dataTestId}
+      />
+    );
+
+    expect(screen.queryByTestId(`${dataTestId}-quantity-plus`)).not.toBeInTheDocument();
+    expect(screen.getByDisplayValue(actionQuantityInput.value)).toBeVisible();
+    expect(screen.getByDisplayValue(actionQuantityInput.value)).toHaveAttribute('readonly');
+    expect(screen.queryByTestId(`${dataTestId}-quantity-minus`)).not.toBeInTheDocument();
+  });
+
+  describe('Stock', () => {
+    it('should render content correctly', () => {
+      render(
+        <ProductQuantityActions actionQuantityInput={actionQuantityInput} stock={stock} dataTestId={dataTestId} />
+      );
+
+      expect(screen.getByText(stock.label)).toBeVisible();
+      expect(screen.getByTestId(`${dataTestId}-stock-info`)).toBeVisible();
+      expect(screen.queryByTestId(`${dataTestId}-availability`)).not.toBeInTheDocument();
+    });
+
+    it('should not render info dot status', () => {
+      render(
+        <ProductQuantityActions
+          actionQuantityInput={actionQuantityInput}
+          stock={{ label: stock.label }}
+          dataTestId={dataTestId}
+        />
+      );
+
+      expect(screen.queryByTestId(`${dataTestId}-stock-info`)).not.toBeInTheDocument();
+    });
+
+    it('should render available text correctly', () => {
+      const availability = 'Available: 12/03/2021';
+
+      render(
+        <ProductQuantityActions
+          actionQuantityInput={actionQuantityInput}
+          stock={{ ...stock, availability }}
+          dataTestId={dataTestId}
+        />
+      );
+
+      expect(screen.getByText(availability)).toBeVisible();
+    });
   });
 });

--- a/malty/molecules/ProductQuantityActions/ProductQuantityActions.tsx
+++ b/malty/molecules/ProductQuantityActions/ProductQuantityActions.tsx
@@ -8,6 +8,7 @@ import {
   StyledActions,
   StyledButtonWrapper,
   StyledInputWrapper,
+  StyledReadOnlyInput,
   StyledStock,
   StyledStockStatusColor
 } from './ProductQuantityActions.styled';
@@ -20,26 +21,20 @@ export const ProductQuantityActions = ({
   dataTestId = 'default'
 }: ProductQuantityActionsProps) => {
   const theme = useContext(ThemeContext) || defaultTheme;
+  const isReadOnly = actionQuantityInput?.readOnly;
 
   const handleStopPropagation = (event: MouseEvent<HTMLInputElement>) => {
     event.stopPropagation();
   };
 
-  return (
-    <>
-      {stock ? (
-        <StyledStock theme={theme}>
-          {stock.stockColor && <StyledStockStatusColor theme={theme} infoColor={stock.stockColor} />}
-          <Text textStyle={TextStyle.SmallBold} color={stock.labelColor}>
-            {stock.label}
-          </Text>
-          {stock.availability && (
-            <Text textStyle={TextStyle.SmallDefault} color={TextColor.Support100}>
-              {stock.availability}
-            </Text>
-          )}
-        </StyledStock>
-      ) : null}
+  const renderContent = () => {
+    if (!actionQuantityInput && !actionButton) return null;
+
+    if (isReadOnly) {
+      return <StyledReadOnlyInput readOnly type={InputType.Number} value={actionQuantityInput.value} />;
+    }
+
+    return (
       <StyledActions theme={theme}>
         {actionQuantityInput ? (
           <StyledInputWrapper>
@@ -52,16 +47,43 @@ export const ProductQuantityActions = ({
             />
           </StyledInputWrapper>
         ) : null}
-        <StyledButtonWrapper hasIcon={!!actionButton.icon} hasActionQuantityInput={!!actionQuantityInput}>
-          <Button
-            {...actionButton}
-            text={actionButton.icon ? undefined : actionButton.text}
-            fullWidth
-            dataTestId={`${dataTestId}-button`}
-            size={ButtonSize.Medium}
-          />
-        </StyledButtonWrapper>
+        {actionButton ? (
+          <StyledButtonWrapper hasIcon={!!actionButton.icon} hasActionQuantityInput={!!actionQuantityInput}>
+            <Button
+              {...actionButton}
+              text={actionButton.icon ? undefined : actionButton.text}
+              fullWidth
+              dataTestId={`${dataTestId}-button`}
+              size={ButtonSize.Medium}
+            />
+          </StyledButtonWrapper>
+        ) : null}
       </StyledActions>
+    );
+  };
+
+  return (
+    <>
+      {stock ? (
+        <StyledStock theme={theme} data-testid={`${dataTestId}-stock`}>
+          {stock.stockColor && (
+            <StyledStockStatusColor
+              theme={theme}
+              infoColor={stock.stockColor}
+              data-testid={`${dataTestId}-stock-info`}
+            />
+          )}
+          <Text textStyle={TextStyle.SmallBold} color={stock.labelColor}>
+            {stock.label}
+          </Text>
+          {stock.availability && (
+            <Text textStyle={TextStyle.SmallDefault} color={TextColor.Support100}>
+              {stock.availability}
+            </Text>
+          )}
+        </StyledStock>
+      ) : null}
+      {renderContent()}
     </>
   );
 };

--- a/malty/molecules/ProductQuantityActions/ProductQuantityActions.types.ts
+++ b/malty/molecules/ProductQuantityActions/ProductQuantityActions.types.ts
@@ -8,12 +8,14 @@ export interface Stock {
   stockColor?: TextColor;
   availability?: string;
 }
+
 export type ActionButton = Pick<ButtonProps, 'text' | 'icon' | 'style' | 'disabled' | 'loading' | 'color' | 'onClick'>;
 
 export type ActionQuantityInput = Pick<InputProps, 'value' | 'min' | 'max' | 'readOnly' | 'onValueChange'>;
+
 export interface ProductQuantityActionsProps {
   dataTestId?: string;
   stock?: Stock;
   actionQuantityInput?: ActionQuantityInput;
-  actionButton: ActionButton;
+  actionButton?: ActionButton;
 }


### PR DESCRIPTION
# What

<!-- Describe the technical "why" behind your changes -->
In this task we are adding the possibility to display the quantity content as readOnly, in order to do that we had to edit the ActionQuantityInput, so in order to use the new visual from ProductCard we need to pass the property readOnly as true on the actionQuantityInput prop object


This one is the final solution from this specific [closed PR](https://github.com/CarlsbergGBS/cx-component-library/pull/768)

## Code Quality Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have updated storybook (if appropriate)

## Jira Card

<!-- if no card is associated, remove the line bellow and add "Not Applicable" -->

DSM-785
