### PR TITLE
fix(pagination): add background-color white to the input

### DIFF
--- a/malty/molecules/Pagination/Pagination.styled.ts
+++ b/malty/molecules/Pagination/Pagination.styled.ts
@@ -79,7 +79,7 @@ export const StyledInputPagination = styled.div`
 export const StyledInput = styled.input`
   width: ${({ theme }) => theme.sizes['3xl'].value};
   height: ${({ theme }) => theme.sizes.xl.value};
-
+  background-color: ${({ theme }) => theme.colors.colours.default.white.value};
   box-sizing: border-box;
   font-family: ${({ theme }) => theme.typography.desktop.text['medium-small_default']['font-family'].value};
   font-size: ${({ theme }) => theme.typography.desktop.text['medium-small_default']['font-size'].value};


### PR DESCRIPTION
# What

<!-- Describe the technical "why" behind your changes -->

- Add background-color to the input (Input type pagination) to fix the difference on the styles across browsers when the disable prop is set to true.

## Code Quality Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have updated storybook (if appropriate)

## Jira Card

<!-- if no card is associated, remove the line bellow and add "Not Applicable" -->

Not Applicable
