### PR TITLE
feat(datepicker): [DSM-967] add support for `onClose` callback

### DIFF
--- a/malty/molecules/Datepicker/Datepicker.stories.tsx
+++ b/malty/molecules/Datepicker/Datepicker.stories.tsx
@@ -72,6 +72,9 @@ const meta: Meta<DatepickerProps> = {
     onChange: {
       description: 'Action to perform when clicking a calendar day'
     },
+    onClose: {
+      description: 'Action to perform when datepicker is closed'
+    },
     minDate: {
       description: 'Disable days before defined min. date',
       control: 'date'

--- a/malty/molecules/Datepicker/Datepicker.test.tsx
+++ b/malty/molecules/Datepicker/Datepicker.test.tsx
@@ -130,4 +130,70 @@ describe('datepicker', () => {
 
     expect(screen.getByDisplayValue('01/12/2022')).toBeInTheDocument();
   });
+
+  it('should call `onClose` when datepicker is closed', () => {
+    const onClose = jest.fn();
+
+    render(<Datepicker {...defaultProps} startDate={new Date(2023, 12, 15)} onClose={onClose} />);
+
+    userEvent.click(screen.getByLabelText(defaultProps.label));
+
+    expect(onClose).not.toHaveBeenCalled();
+
+    const dayToBeClicked = screen.getByText('16');
+
+    userEvent.click(dayToBeClicked);
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('should call `onClose` when datepicker is closed using selectsRange', () => {
+    const onClose = jest.fn();
+
+    render(<Datepicker {...defaultProps} startDate={new Date(2023, 12, 15)} onClose={onClose} selectsRange />);
+
+    userEvent.click(screen.getByLabelText(defaultProps.label));
+
+    expect(onClose).not.toHaveBeenCalled();
+
+    const firstDay = screen.getByText('16');
+    const secondDay = screen.getByText('17');
+
+    userEvent.click(firstDay);
+    userEvent.click(secondDay);
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('should call `onClose` when clicking on the primary action', () => {
+    const onClose = jest.fn();
+
+    render(<Datepicker {...defaultProps} onClose={onClose} primaryAction={{ label: 'Confirm', action: jest.fn() }} />);
+
+    userEvent.click(screen.getByLabelText(defaultProps.label));
+
+    expect(onClose).not.toHaveBeenCalled();
+
+    const confirmButton = screen.getByRole('button', { name: 'Confirm' });
+
+    userEvent.click(confirmButton);
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('should call `onClose` when clicking on the secondary action', () => {
+    const onClose = jest.fn();
+
+    render(<Datepicker {...defaultProps} onClose={onClose} secondaryAction={{ label: 'Cancel', action: jest.fn() }} />);
+
+    userEvent.click(screen.getByLabelText(defaultProps.label));
+
+    expect(onClose).not.toHaveBeenCalled();
+
+    const cancelButton = screen.getByRole('button', { name: 'Cancel' });
+
+    userEvent.click(cancelButton);
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
 });

--- a/malty/molecules/Datepicker/Datepicker.tsx
+++ b/malty/molecules/Datepicker/Datepicker.tsx
@@ -39,6 +39,7 @@ export const Datepicker = ({
   startDate,
   endDate,
   onChange,
+  onClose,
   label,
   locale,
   minDate,
@@ -70,7 +71,11 @@ export const Datepicker = ({
   const endDateRef = useRef<Date | null | undefined>(endDate);
   const datepickerRef = useRef<HTMLDivElement>(null);
 
-  const handleClose = useCallback(() => setOpen(false), []);
+  const handleClose = useCallback(() => {
+    setOpen(false);
+    onClose?.();
+  }, [onClose]);
+
   const handleOpen = useCallback(() => setOpen(true), []);
 
   const handlePrimaryAction = () => {

--- a/malty/molecules/Datepicker/Datepicker.types.ts
+++ b/malty/molecules/Datepicker/Datepicker.types.ts
@@ -2,6 +2,7 @@ export interface DatepickerProps {
   label?: string;
   startDate: Date | null;
   onChange: (date: (Date | null) | [Date | null, Date | null]) => void;
+  onClose?: () => void;
   locale?: string;
   minDate?: Date;
   maxDate?: Date;


### PR DESCRIPTION
# What

The goal of this change is to enable validations on this field after the datepicker is closed without filling in the required values.

This is an example from Cadi's backoffice, where the input start as empty and the user can open / close datepicker without choosing any value.

![image](https://github.com/CarlsbergGBS/cx-component-library/assets/13966565/9d2e17a0-ce8d-450e-9cd5-6798488c4ab8)

Initially, we though the `onBlur` was the more correct approach here, but the datepicker behaves differently from other simple inputs because when the focus is lost from the date input it goes to the dialog with the days / months etc, and that by definition it's already a `onBlur` happening. To follow with that approach we would need to come up with some trick to make the onBlur trigger only when the user actually left the field. After further brainstorm with @SergioVanacloigCarlsberg the `onClose` seemed like the simple solution with the desired outcome.

## Code Quality Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)
- [x] I have updated storybook (if appropriate)

## Jira Card

<!-- if no card is associated, remove the line bellow and add "Not Applicable" -->

DSM-967
