### PR TITLE
fix(radio): [CADI-16915] revert change of Radio selected prop

### DIFF
--- a/malty/atoms/Radio/Radio.tsx
+++ b/malty/atoms/Radio/Radio.tsx
@@ -35,7 +35,7 @@ export const Radio = ({
         <StyledRadio
           data-testid={dataTestId}
           id={id.current}
-          defaultChecked={selected}
+          checked={selected}
           value={value}
           theme={theme}
           type="radio"


### PR DESCRIPTION
# What

<!-- Describe the technical "why" behind your changes -->
- Revert change of Radio component `selected` behavior. After changing behavior of the prop `selected` to stop using `checked` and start using `defaultChecked` instead, which can only be used in uncontrolled components, we had breaking changes in controlled components that were previously using it. As we expected to use the `selected` prop for more use cases, other than only for the first render of the component, we had to revert it. Note that we can still pass the `defaultChecked` prop directly to the component, as the Radio component extends the HTMLInputElement props.

References: 
- https://legacy.reactjs.org/docs/dom-elements.html#checked
- https://react.dev/reference/react-dom/components/input#props

## Code Quality Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have updated storybook (if appropriate)
- [ ] I have ran `yarn set-peer-dep` when adding an icon as a dependency of another component (if appropriate) [read more](https://carlsberggbs.atlassian.net/wiki/spaces/DSM/pages/4697162121/Components+as+peer+dependency)

## Jira Card

<!-- if no card is associated, remove the line bellow and add "Not Applicable" -->

CADI-16915
