### PR TITLE
feat(global): integrate the new tokens version

### DIFF
--- a/.bitmap
+++ b/.bitmap
@@ -1635,6 +1635,12 @@
         "mainFile": "index.tsx",
         "rootDir": "malty/theme/MaltyThemeProvider"
     },
+    "theme/new-malty-theme-provider": {
+        "scope": "",
+        "version": "",
+        "mainFile": "index.ts",
+        "rootDir": "malty/theme/NewMaltyThemeProvider"
+    },
     "utils/all-icons": {
         "scope": "carlsberggroup.malty",
         "version": "0.0.2",

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,4 +1,5 @@
 import { MaltyThemeProvider } from '@carlsberggroup/malty.theme.malty-theme-provider';
+import { defaultTheme, NewMaltyThemeProvider } from '@carlsberggroup/malty.theme.new-malty-theme-provider';
 import { Controls, Description, DocsContainer, Primary, Stories, Subtitle, Title } from '@storybook/addon-docs';
 import React from 'react';
 import styled from 'styled-components';
@@ -15,7 +16,9 @@ const options = params.get('options');
 export const decorators = [
   (Story, context) => (
     <MaltyThemeProvider theme={context.globals.theme}>
-      <Story />
+      <NewMaltyThemeProvider theme={defaultTheme}>
+        <Story />
+      </NewMaltyThemeProvider>
     </MaltyThemeProvider>
   )
 ];

--- a/malty/theme/MaltyThemeProvider/styled.d.ts
+++ b/malty/theme/MaltyThemeProvider/styled.d.ts
@@ -1,9 +1,18 @@
-/* eslint-disable prettier/prettier */
-/* eslint-disable camelcase */
 import 'styled-components';
+import {
+  BorderRadiusTokens,
+  BorderTokens,
+  ColorTokens,
+  GridTokens,
+  OpacityTokens,
+  ShadowTokens,
+  SizeTokens,
+  TypographyTokens
+} from '../NewMaltyThemeProvider/tokens/types';
 
 declare module 'styled-components' {
-  export interface DefaultTheme {
+  export type DefaultTheme = DefaultThemeV1 | DefaultThemeV2;
+  export interface DefaultThemeV1 {
     colors: ColorsType;
     sizes: SizesType;
     layout: LayoutType;
@@ -11,7 +20,17 @@ declare module 'styled-components' {
     gradients: GradientsType;
     typography: TypographyType;
     variables: VariablesType;
-    shadows: ShadowsType;
+  }
+
+  export interface DefaultThemeV2 {
+    colorsV2: ColorTokens;
+    sizesV2: SizeTokens;
+    borderRadiusV2: BorderRadiusTokens;
+    bordersV2: BorderTokens;
+    opacityV2: OpacityTokens;
+    shadowsV2: ShadowTokens;
+    typographyV2: TypographyTokens;
+    gridV2: GridTokens;
   }
 
   interface SizesType {

--- a/malty/theme/NewMaltyThemeProvider/NewMaltyThemeProvider.tsx
+++ b/malty/theme/NewMaltyThemeProvider/NewMaltyThemeProvider.tsx
@@ -1,0 +1,16 @@
+import { TypographyProvider } from '@carlsberggroup/malty.theme.malty-theme-provider';
+import React from 'react';
+import { ThemeProvider } from 'styled-components';
+import defaultTheme from './defaultTheme';
+import { NewMaltyThemeProviderProps } from './NewMaltyThemeProvider.types';
+
+export const NewMaltyThemeProvider = ({ theme, children }: NewMaltyThemeProviderProps) => {
+  const finalTheme = theme ?? defaultTheme;
+
+  return (
+    <ThemeProvider theme={finalTheme}>
+      <TypographyProvider />
+      {children}
+    </ThemeProvider>
+  );
+};

--- a/malty/theme/NewMaltyThemeProvider/NewMaltyThemeProvider.types.ts
+++ b/malty/theme/NewMaltyThemeProvider/NewMaltyThemeProvider.types.ts
@@ -1,0 +1,7 @@
+import { ReactNode } from 'react';
+import { DefaultThemeV2 } from 'styled-components';
+
+export interface NewMaltyThemeProviderProps {
+  theme?: DefaultThemeV2;
+  children: ReactNode;
+}

--- a/malty/theme/NewMaltyThemeProvider/createTheme.ts
+++ b/malty/theme/NewMaltyThemeProvider/createTheme.ts
@@ -1,0 +1,63 @@
+import { DefaultThemeV2 } from 'styled-components';
+import { deepMerge } from './helpers';
+import {
+  borders,
+  grid,
+  opacity,
+  primitiveBorderRadius,
+  primitiveColors,
+  semanticBorderRadius,
+  semanticColors,
+  shadows,
+  sizes,
+  typography
+} from './tokens';
+import { AdditionalPrimitives, SemanticOverrides } from './tokens/types';
+
+interface CreateThemeParams {
+  additionalPrimitives?: AdditionalPrimitives;
+  semanticOverrides?: SemanticOverrides;
+}
+
+export default function createTheme({
+  additionalPrimitives,
+  semanticOverrides
+}: CreateThemeParams = {}): DefaultThemeV2 {
+  // COLORS
+  const finalPrimitiveColors = { ...additionalPrimitives, ...primitiveColors };
+  const finalSemanticColors = semanticOverrides?.colors
+    ? deepMerge(semanticColors, semanticOverrides.colors)
+    : semanticColors;
+
+  // TYPOGRAPHY
+  const finalTypography = semanticOverrides?.typography
+    ? deepMerge(typography, semanticOverrides.typography)
+    : typography;
+
+  // BORDERS
+  const finalBorders = semanticOverrides?.borders ? deepMerge(borders, semanticOverrides.borders) : borders;
+
+  // BORDER RADIUS
+  const finalSemanticBorderRadius = semanticOverrides?.borderRadius
+    ? deepMerge(semanticBorderRadius, semanticOverrides.borderRadius)
+    : semanticBorderRadius;
+
+  const theme = {
+    colorsV2: {
+      ...finalPrimitiveColors,
+      ...finalSemanticColors
+    },
+    sizesV2: { ...sizes },
+    borderRadiusV2: {
+      ...primitiveBorderRadius,
+      ...finalSemanticBorderRadius
+    },
+    bordersV2: { ...finalBorders },
+    opacityV2: { ...opacity },
+    shadowsV2: { ...shadows },
+    gridV2: { ...grid },
+    typographyV2: { ...finalTypography }
+  };
+
+  return theme;
+}

--- a/malty/theme/NewMaltyThemeProvider/defaultTheme.ts
+++ b/malty/theme/NewMaltyThemeProvider/defaultTheme.ts
@@ -1,0 +1,32 @@
+import { DefaultThemeV2 } from 'styled-components';
+import {
+  borders,
+  grid,
+  opacity,
+  primitiveBorderRadius,
+  primitiveColors,
+  semanticBorderRadius,
+  semanticColors,
+  shadows,
+  sizes,
+  typography
+} from './tokens';
+
+const defaultTheme: DefaultThemeV2 = {
+  colorsV2: {
+    ...primitiveColors,
+    ...semanticColors
+  },
+  sizesV2: { ...sizes },
+  borderRadiusV2: {
+    ...primitiveBorderRadius,
+    ...semanticBorderRadius
+  },
+  bordersV2: { ...borders },
+  opacityV2: { ...opacity },
+  shadowsV2: { ...shadows },
+  gridV2: { ...grid },
+  typographyV2: { ...typography }
+};
+
+export default defaultTheme;

--- a/malty/theme/NewMaltyThemeProvider/helpers.ts
+++ b/malty/theme/NewMaltyThemeProvider/helpers.ts
@@ -1,0 +1,22 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function isObject(item: any) {
+  return item && typeof item === 'object' && !Array.isArray(item);
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function deepMerge(target?: any, ...sources: any[]): any {
+  if (!sources.length) return target;
+  const source = sources.shift();
+
+  if (isObject(target) && isObject(source)) {
+    Object.keys(source).forEach((key) => {
+      if (isObject(source[key])) {
+        if (!target[key]) Object.assign(target, { [key]: {} });
+        deepMerge(target[key], source[key]);
+      } else {
+        Object.assign(target, { [key]: source[key] });
+      }
+    });
+  }
+  return deepMerge(target, ...sources);
+}

--- a/malty/theme/NewMaltyThemeProvider/index.ts
+++ b/malty/theme/NewMaltyThemeProvider/index.ts
@@ -1,0 +1,6 @@
+export { default as createTheme } from './createTheme';
+export { default as defaultTheme } from './defaultTheme';
+export { NewMaltyThemeProvider } from './NewMaltyThemeProvider';
+export type { NewMaltyThemeProviderProps } from './NewMaltyThemeProvider.types';
+export { borders, primitiveBorderRadius, primitiveColors, semanticColors, sizes, typography } from './tokens';
+export type { AdditionalPrimitives, SemanticOverrides } from './tokens/types';

--- a/malty/theme/NewMaltyThemeProvider/tokens/helpers/helpers.ts
+++ b/malty/theme/NewMaltyThemeProvider/tokens/helpers/helpers.ts
@@ -1,0 +1,220 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+const primitives = require('./primitives.json');
+const semantics = require('./semantics.json');
+
+// PRIMITIVE COLORS
+export function getPrimitiveColors() {
+  const { colors } = primitives;
+
+  const primitiveColors: { [key: string]: { [shade: string]: string } } = {};
+
+  Object.keys(colors).forEach((key) => {
+    const color = colors[key as keyof typeof colors] as { [shade: string]: { value: string } };
+
+    Object.keys(color).forEach((shade) => {
+      if (!primitiveColors[key]) {
+        primitiveColors[key] = {};
+      }
+
+      primitiveColors[key][shade] = color[shade].value;
+    });
+  });
+
+  return primitiveColors;
+}
+
+// SEMANTIC COLORS
+export function getSemanticColors(primitiveColors: { [key: string]: { [shade: string]: string } }) {
+  const getSemanticToken = (value: string): string => {
+    const tempValue = value.substring(1, value.length - 1);
+    const [_, token1, token2] = tempValue.split('.');
+
+    return primitiveColors[token1][token2];
+  };
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const finalSemanticColors: any = { ...semantics.colors };
+
+  for (const mode of Object.keys(finalSemanticColors)) {
+    const modeObject = { ...finalSemanticColors[mode] };
+    finalSemanticColors[mode] = modeObject;
+
+    for (const type of Object.keys(modeObject)) {
+      const typeObject = { ...modeObject[type] };
+      modeObject[type] = typeObject;
+
+      if (['background', 'foreground'].includes(type)) {
+        for (const subType of Object.keys(typeObject)) {
+          const subTypeObject = { ...typeObject[subType] };
+          typeObject[subType] = subTypeObject;
+
+          for (const state of Object.keys(subTypeObject)) {
+            subTypeObject[state] = getSemanticToken(subTypeObject[state].value);
+          }
+        }
+      } else {
+        for (const shade of Object.keys(typeObject)) {
+          typeObject[shade] = getSemanticToken(typeObject[shade].value);
+        }
+      }
+    }
+  }
+
+  return finalSemanticColors;
+}
+
+// SIZES, BORDER RADIUS, OPACITY
+export function getDefaultPrimitiveTokens(item: string) {
+  const rawTokens = primitives[item as keyof typeof primitives];
+
+  const transformedTokens: { [key: string]: string } = {};
+
+  Object.keys(rawTokens).forEach((key) => {
+    transformedTokens[key] = (rawTokens[key as keyof typeof rawTokens] as { value: string }).value;
+  });
+
+  return transformedTokens;
+}
+
+export function getDefaultSemanticTokens(item: string, primitiveObj: { [key: string]: string }) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const rawTokens: any = semantics[item as keyof typeof semantics];
+
+  const transformedTokens: { [key: string]: string } = {};
+
+  Object.keys(rawTokens).forEach((key) => {
+    const token = rawTokens[key].value;
+    const tempValue = token.substring(1, token.length - 1);
+    const [_, token1] = tempValue.split('.');
+    transformedTokens[key] = primitiveObj[token1];
+  });
+
+  return transformedTokens;
+}
+
+// BORDERS
+export function getPrimitiveBorderTokens(primitiveColors: { [key: string]: { [shade: string]: string } }) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const finalPrimitiveBorderTokens: any = { ...primitives.border };
+
+  for (const type of Object.keys(finalPrimitiveBorderTokens)) {
+    const tempObject = { ...finalPrimitiveBorderTokens[type].value };
+    const tempValue = tempObject.color.substring(1, tempObject.color.length - 1);
+    const [_, token1, token2] = tempValue.split('.');
+
+    finalPrimitiveBorderTokens[type] = {
+      color: primitiveColors[token1][token2],
+      width: tempObject.width,
+      style: tempObject.style
+    };
+  }
+  return finalPrimitiveBorderTokens;
+}
+
+// SHADOWS
+export function getShadowTokens() {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const rawShadows: any = primitives['box shadow'];
+
+  const shadowTokens: { [key: string]: string } = {};
+
+  Object.keys(rawShadows).forEach((key) => {
+    const shadow = rawShadows[key].value;
+
+    if (Array.isArray(shadow)) {
+      shadowTokens[key] = shadow.map(getShadowValue).join(', ');
+    } else {
+      shadowTokens[key] = getShadowValue(shadow);
+    }
+  });
+
+  return shadowTokens;
+}
+
+function getShadowValue(shadow: { x: number; y: number; blur: number; spread: number; color: string }) {
+  return `${shadow.x}px ${shadow.y}px ${shadow.blur}px ${shadow.spread}px ${shadow.color}`;
+}
+
+// TYPOGRAPHY
+export function getTypographyTokens() {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const finalTypography: { [key: string]: any } = {};
+
+  for (const fontFamily of Object.keys(primitives.fontFamilies)) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const value = (primitives.fontFamilies as any)[fontFamily].value.toLowerCase();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    finalTypography[fontFamily] = { ...(primitives as any)[value] };
+  }
+
+  const getSemanticToken = (value: string): string => {
+    const tempValue = value.substring(1, value.length - 1);
+    const [token0, token1] = tempValue.split('.');
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return (primitives as any)[token0][token1].value;
+  };
+
+  for (const font of Object.keys(finalTypography)) {
+    const fontObject = { ...finalTypography[font] };
+    finalTypography[font] = fontObject;
+
+    for (const section of Object.keys(fontObject)) {
+      const sectionObject = { ...fontObject[section] };
+      fontObject[section] = sectionObject;
+
+      for (const size of Object.keys(sectionObject)) {
+        const sizeObject = { ...sectionObject[size] };
+        sectionObject[size] = sizeObject;
+
+        for (const weight of Object.keys(sizeObject)) {
+          const tempObject = sizeObject[weight].value;
+
+          sizeObject[weight] = {
+            fontFamily: `${getSemanticToken(tempObject.fontFamily)}, 'sans-serif'`,
+            fontWeight: sizeObject[weight].description,
+            lineHeight: `${getSemanticToken(tempObject.lineHeight)}px`,
+            fontSize: `${getSemanticToken(tempObject.fontSize)}px`,
+            letterSpacing: `${getSemanticToken(tempObject.letterSpacing)}px`,
+            paragraphSpacing: `${getSemanticToken(tempObject.paragraphSpacing)}px`,
+            paragraphIndent: `${getSemanticToken(tempObject.paragraphIndent)}`,
+            textCase: getSemanticToken(tempObject.textCase),
+            textDecoration: getSemanticToken(tempObject.textDecoration)
+          };
+        }
+      }
+    }
+  }
+
+  return finalTypography;
+}
+
+// GRID
+export function getGridTokens() {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const finalGridTokens: any = { ...semantics.grid };
+
+  for (const size of Object.keys(finalGridTokens)) {
+    const sizeObject = { ...finalGridTokens[size] };
+    finalGridTokens[size] = sizeObject;
+
+    for (const type of Object.keys(sizeObject)) {
+      const tempObject = sizeObject[type];
+
+      sizeObject[type] = {
+        columns: tempObject.columns.value,
+        minWidth: `${tempObject.minWidth.value}px`,
+        margin: `${tempObject.margin.value}px`,
+        gutter: `${tempObject.gutter.value}px`,
+        container:
+          size === 'xl' && type === 'fixed' ? `${tempObject.container.value}px` : `${tempObject.container.value}%`
+      };
+
+      if (size !== 'xl') {
+        sizeObject[type].maxWidth = `${tempObject.maxWidth.value}px`;
+      }
+    }
+  }
+
+  return finalGridTokens;
+}

--- a/malty/theme/NewMaltyThemeProvider/tokens/helpers/index.ts
+++ b/malty/theme/NewMaltyThemeProvider/tokens/helpers/index.ts
@@ -1,0 +1,1 @@
+export * from './helpers';

--- a/malty/theme/NewMaltyThemeProvider/tokens/helpers/primitives.json
+++ b/malty/theme/NewMaltyThemeProvider/tokens/helpers/primitives.json
@@ -1,0 +1,4031 @@
+{
+  "sizes": {
+    "4xs": {
+      "value": "0px",
+      "type": "dimension",
+      "parent": "global/Value",
+      "description": ""
+    },
+    "3xs": {
+      "value": "2px",
+      "type": "dimension",
+      "parent": "global/Value",
+      "description": ""
+    },
+    "2xs": {
+      "value": "4px",
+      "type": "dimension",
+      "parent": "global/Value",
+      "description": ""
+    },
+    "xs": {
+      "value": "8px",
+      "type": "dimension",
+      "parent": "global/Value",
+      "description": ""
+    },
+    "s": {
+      "value": "12px",
+      "type": "dimension",
+      "parent": "global/Value",
+      "description": ""
+    },
+    "m": {
+      "value": "16px",
+      "type": "dimension",
+      "parent": "global/Value",
+      "description": ""
+    },
+    "l": {
+      "value": "20px",
+      "type": "dimension",
+      "parent": "global/Value",
+      "description": ""
+    },
+    "xl": {
+      "value": "24px",
+      "type": "dimension",
+      "parent": "global/Value",
+      "description": ""
+    },
+    "2xl": {
+      "value": "28px",
+      "type": "dimension",
+      "parent": "global/Value",
+      "description": ""
+    },
+    "3xl": {
+      "value": "32px",
+      "type": "dimension",
+      "parent": "global/Value",
+      "description": ""
+    },
+    "4xl": {
+      "value": "36px",
+      "type": "dimension",
+      "parent": "global/Value",
+      "description": ""
+    },
+    "5xl": {
+      "value": "40px",
+      "type": "dimension",
+      "parent": "global/Value",
+      "description": ""
+    },
+    "6xl": {
+      "value": "44px",
+      "type": "dimension",
+      "parent": "global/Value",
+      "description": ""
+    },
+    "7xl": {
+      "value": "48px",
+      "type": "dimension",
+      "parent": "global/Value",
+      "description": ""
+    },
+    "8xl": {
+      "value": "52px",
+      "type": "dimension",
+      "parent": "global/Value",
+      "description": ""
+    },
+    "9xl": {
+      "value": "56px",
+      "type": "dimension",
+      "parent": "global/Value",
+      "description": ""
+    },
+    "10xl": {
+      "value": "60px",
+      "type": "dimension",
+      "parent": "global/Value",
+      "description": ""
+    },
+    "11xl": {
+      "value": "64px",
+      "type": "dimension",
+      "parent": "global/Value",
+      "description": ""
+    },
+    "12xl": {
+      "value": "68px",
+      "type": "dimension",
+      "parent": "global/Value",
+      "description": ""
+    },
+    "13xl": {
+      "value": "72px",
+      "type": "dimension",
+      "parent": "global/Value",
+      "description": ""
+    },
+    "14xl": {
+      "value": "76px",
+      "type": "dimension",
+      "parent": "global/Value",
+      "description": ""
+    },
+    "15xl": {
+      "value": "80px",
+      "type": "dimension",
+      "parent": "global/Value",
+      "description": ""
+    }
+  },
+  "border radius": {
+    "square": {
+      "value": "0px",
+      "type": "dimension",
+      "parent": "global/Value",
+      "description": ""
+    },
+    "rounded": {
+      "value": "4px",
+      "type": "dimension",
+      "parent": "global/Value",
+      "description": ""
+    },
+    "round": {
+      "value": "999999px",
+      "type": "dimension",
+      "parent": "global/Value",
+      "description": ""
+    }
+  },
+  "box shadow": {
+    "100": {
+      "value": [
+        {
+          "color": "#1018281a",
+          "type": "dropShadow",
+          "x": "0",
+          "y": "4",
+          "blur": "8",
+          "spread": "0"
+        },
+        {
+          "color": "#1018280f",
+          "type": "dropShadow",
+          "x": "0",
+          "y": "2",
+          "blur": "4",
+          "spread": "0"
+        }
+      ],
+      "type": "boxShadow",
+      "oldValue": [
+        {
+          "color": "#1018281a",
+          "type": "dropShadow",
+          "x": "0",
+          "y": "4",
+          "blur": "8",
+          "spread": "0"
+        },
+        {
+          "color": "#1018280f",
+          "type": "dropShadow",
+          "x": "0",
+          "y": "2",
+          "blur": "4",
+          "spread": "0"
+        }
+      ]
+    },
+    "200": {
+      "value": [
+        {
+          "color": "#10182814",
+          "type": "dropShadow",
+          "x": "0",
+          "y": "12",
+          "blur": "16",
+          "spread": "0"
+        },
+        {
+          "color": "#10182808",
+          "type": "dropShadow",
+          "x": "0",
+          "y": "4",
+          "blur": "6",
+          "spread": "0"
+        }
+      ],
+      "type": "boxShadow",
+      "oldValue": [
+        {
+          "color": "#10182814",
+          "type": "dropShadow",
+          "x": "0",
+          "y": "12",
+          "blur": "16",
+          "spread": "0"
+        },
+        {
+          "color": "#10182808",
+          "type": "dropShadow",
+          "x": "0",
+          "y": "4",
+          "blur": "6",
+          "spread": "0"
+        }
+      ]
+    },
+    "300": {
+      "value": [
+        {
+          "color": "#10182814",
+          "type": "dropShadow",
+          "x": "0",
+          "y": "20",
+          "blur": "24",
+          "spread": "0"
+        },
+        {
+          "color": "#10182808",
+          "type": "dropShadow",
+          "x": "0",
+          "y": "8",
+          "blur": "8",
+          "spread": "0"
+        }
+      ],
+      "type": "boxShadow",
+      "oldValue": [
+        {
+          "color": "#10182814",
+          "type": "dropShadow",
+          "x": "0",
+          "y": "20",
+          "blur": "24",
+          "spread": "0"
+        },
+        {
+          "color": "#10182808",
+          "type": "dropShadow",
+          "x": "0",
+          "y": "8",
+          "blur": "8",
+          "spread": "0"
+        }
+      ]
+    },
+    "400": {
+      "value": {
+        "color": "#1018282e",
+        "type": "dropShadow",
+        "x": "0",
+        "y": "24",
+        "blur": "48",
+        "spread": "0"
+      },
+      "type": "boxShadow",
+      "oldValue": {
+        "color": "#1018282e",
+        "type": "dropShadow",
+        "x": "0",
+        "y": "24",
+        "blur": "48",
+        "spread": "0"
+      }
+    }
+  },
+  "lineHeights": {
+    "0": {
+      "value": "12",
+      "type": "lineHeights"
+    },
+    "1": {
+      "value": "16",
+      "type": "lineHeights"
+    },
+    "2": {
+      "value": "18",
+      "type": "lineHeights"
+    },
+    "3": {
+      "value": "24",
+      "type": "lineHeights"
+    },
+    "4": {
+      "value": "28",
+      "type": "lineHeights"
+    },
+    "5": {
+      "value": "32",
+      "type": "lineHeights"
+    },
+    "6": {
+      "value": "44",
+      "type": "lineHeights"
+    },
+    "7": {
+      "value": "52",
+      "type": "lineHeights"
+    },
+    "8": {
+      "value": "64",
+      "type": "lineHeights"
+    }
+  },
+  "fontWeights": {
+    "montserrat-0": {
+      "value": "Regular",
+      "type": "fontWeights",
+      "description": "400"
+    },
+    "montserrat-1": {
+      "value": "SemiBold",
+      "type": "fontWeights",
+      "oldValue": "Bold",
+      "description": "600"
+    },
+    "montserrat-2": {
+      "value": "Bold",
+      "type": "fontWeights",
+      "oldValue": "Light",
+      "description": "700"
+    },
+    "montserrat-3": {
+      "value": "Light",
+      "type": "fontWeights",
+      "oldValue": "Black",
+      "description": "300"
+    },
+    "montserrat-4": {
+      "value": "Black",
+      "type": "fontWeights",
+      "oldValue": "ExtraLight",
+      "description": "900"
+    },
+    "noto-sans-lao-looped-5": {
+      "value": "Regular",
+      "type": "fontWeights",
+      "description": "400"
+    },
+    "noto-sans-lao-looped-6": {
+      "value": "Regular",
+      "type": "fontWeights",
+      "oldValue": "Bold",
+      "description": "400"
+    },
+    "noto-sans-lao-looped-7": {
+      "value": "Bold",
+      "type": "fontWeights",
+      "oldValue": "Light",
+      "description": "700"
+    },
+    "noto-sans-lao-looped-8": {
+      "value": "Light",
+      "type": "fontWeights",
+      "oldValue": "Black",
+      "description": "300"
+    },
+    "noto-sans-lao-looped-9": {
+      "value": "Black",
+      "type": "fontWeights",
+      "oldValue": "ExtraLight",
+      "description": "900"
+    },
+    "montserrat-5": {
+      "value": "ExtraLight",
+      "type": "fontWeights",
+      "description": "200"
+    },
+    "noto-sans-lao-looped-10": {
+      "value": "ExtraLight",
+      "type": "fontWeights",
+      "description": "200"
+    }
+  },
+  "fontSize": {
+    "0": {
+      "value": "10",
+      "type": "fontSizes"
+    },
+    "1": {
+      "value": "12",
+      "type": "fontSizes"
+    },
+    "2": {
+      "value": "14",
+      "type": "fontSizes"
+    },
+    "3": {
+      "value": "16",
+      "type": "fontSizes"
+    },
+    "4": {
+      "value": "18",
+      "type": "fontSizes",
+      "oldValue": "20"
+    },
+    "5": {
+      "value": "20",
+      "type": "fontSizes",
+      "oldValue": "24"
+    },
+    "6": {
+      "value": "24",
+      "type": "fontSizes",
+      "oldValue": "32"
+    },
+    "7": {
+      "value": "32",
+      "type": "fontSizes",
+      "oldValue": "48"
+    },
+    "8": {
+      "value": "48",
+      "type": "fontSizes",
+      "oldValue": "56"
+    },
+    "9": {
+      "value": "56",
+      "type": "fontSizes",
+      "oldValue": "72"
+    },
+    "10": {
+      "value": "72",
+      "type": "fontSizes"
+    }
+  },
+  "letterSpacing": {
+    "0": {
+      "value": "0",
+      "type": "letterSpacing"
+    }
+  },
+  "paragraphSpacing": {
+    "0": {
+      "value": "0",
+      "type": "paragraphSpacing"
+    }
+  },
+  "montserrat": {
+    "body": {
+      "10": {
+        "regular": {
+          "value": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-0}",
+            "lineHeight": "{lineHeights.0}",
+            "fontSize": "{fontSize.0}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.none}",
+            "textDecoration": "{textDecoration.none}"
+          },
+          "type": "typography",
+          "description": "400"
+        },
+        "regular-underline": {
+          "value": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-0}",
+            "lineHeight": "{lineHeights.0}",
+            "fontSize": "{fontSize.0}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.none}",
+            "textDecoration": "{textDecoration.underline}"
+          },
+          "type": "typography",
+          "description": "400"
+        },
+        "bold": {
+          "value": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-2}",
+            "lineHeight": "{lineHeights.0}",
+            "fontSize": "{fontSize.0}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.none}",
+            "textDecoration": "{textDecoration.none}"
+          },
+          "type": "typography",
+          "description": "700",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-1}",
+            "lineHeight": "{lineHeights.0}",
+            "fontSize": "{fontSize.0}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.none}",
+            "textDecoration": "{textDecoration.none}"
+          }
+        },
+        "bold-underline": {
+          "value": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-2}",
+            "lineHeight": "{lineHeights.0}",
+            "fontSize": "{fontSize.0}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.none}",
+            "textDecoration": "{textDecoration.underline}"
+          },
+          "type": "typography",
+          "description": "700",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-1}",
+            "lineHeight": "{lineHeights.0}",
+            "fontSize": "{fontSize.0}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.none}",
+            "textDecoration": "{textDecoration.underline}"
+          }
+        },
+        "semibold": {
+          "value": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-1}",
+            "lineHeight": "{lineHeights.0}",
+            "fontSize": "{fontSize.0}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.none}",
+            "textDecoration": "{textDecoration.none}"
+          },
+          "type": "typography",
+          "description": "600"
+        },
+        "semibold-underline": {
+          "value": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-1}",
+            "lineHeight": "{lineHeights.0}",
+            "fontSize": "{fontSize.0}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.none}",
+            "textDecoration": "{textDecoration.underline}"
+          },
+          "type": "typography",
+          "description": "600"
+        }
+      },
+      "12": {
+        "regular": {
+          "value": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-0}",
+            "lineHeight": "{lineHeights.1}",
+            "fontSize": "{fontSize.1}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.none}",
+            "textDecoration": "{textDecoration.none}"
+          },
+          "type": "typography",
+          "description": "400"
+        },
+        "regular-underline": {
+          "value": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-0}",
+            "lineHeight": "{lineHeights.1}",
+            "fontSize": "{fontSize.1}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.none}",
+            "textDecoration": "{textDecoration.underline}"
+          },
+          "type": "typography",
+          "description": "400"
+        },
+        "bold": {
+          "value": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-2}",
+            "lineHeight": "{lineHeights.1}",
+            "fontSize": "{fontSize.1}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.none}",
+            "textDecoration": "{textDecoration.none}"
+          },
+          "type": "typography",
+          "description": "700",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-1}",
+            "lineHeight": "{lineHeights.1}",
+            "fontSize": "{fontSize.1}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.none}",
+            "textDecoration": "{textDecoration.none}"
+          }
+        },
+        "bold-underline": {
+          "value": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-2}",
+            "lineHeight": "{lineHeights.1}",
+            "fontSize": "{fontSize.1}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.none}",
+            "textDecoration": "{textDecoration.underline}"
+          },
+          "type": "typography",
+          "description": "700",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-1}",
+            "lineHeight": "{lineHeights.1}",
+            "fontSize": "{fontSize.1}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.none}",
+            "textDecoration": "{textDecoration.underline}"
+          }
+        },
+        "semibold": {
+          "value": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-1}",
+            "lineHeight": "{lineHeights.1}",
+            "fontSize": "{fontSize.1}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.none}",
+            "textDecoration": "{textDecoration.none}"
+          },
+          "type": "typography",
+          "description": "600"
+        },
+        "semibold-underline": {
+          "value": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-1}",
+            "lineHeight": "{lineHeights.1}",
+            "fontSize": "{fontSize.1}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.none}",
+            "textDecoration": "{textDecoration.underline}"
+          },
+          "type": "typography",
+          "description": "600"
+        }
+      },
+      "14": {
+        "regular": {
+          "value": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-0}",
+            "lineHeight": "{lineHeights.2}",
+            "fontSize": "{fontSize.2}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.none}",
+            "textDecoration": "{textDecoration.none}"
+          },
+          "type": "typography",
+          "description": "400"
+        },
+        "regular-underline": {
+          "value": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-0}",
+            "lineHeight": "{lineHeights.2}",
+            "fontSize": "{fontSize.2}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.none}",
+            "textDecoration": "{textDecoration.underline}"
+          },
+          "type": "typography",
+          "description": "400"
+        },
+        "bold": {
+          "value": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-2}",
+            "lineHeight": "{lineHeights.2}",
+            "fontSize": "{fontSize.2}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.none}",
+            "textDecoration": "{textDecoration.none}"
+          },
+          "type": "typography",
+          "description": "700",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-1}",
+            "lineHeight": "{lineHeights.2}",
+            "fontSize": "{fontSize.2}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.none}",
+            "textDecoration": "{textDecoration.none}"
+          }
+        },
+        "bold-underline": {
+          "value": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-2}",
+            "lineHeight": "{lineHeights.2}",
+            "fontSize": "{fontSize.2}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.none}",
+            "textDecoration": "{textDecoration.underline}"
+          },
+          "type": "typography",
+          "description": "700",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-1}",
+            "lineHeight": "{lineHeights.2}",
+            "fontSize": "{fontSize.2}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.none}",
+            "textDecoration": "{textDecoration.underline}"
+          }
+        },
+        "semibold": {
+          "value": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-1}",
+            "lineHeight": "{lineHeights.2}",
+            "fontSize": "{fontSize.2}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.none}",
+            "textDecoration": "{textDecoration.none}"
+          },
+          "type": "typography",
+          "description": "600"
+        },
+        "semibold-underline": {
+          "value": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-1}",
+            "lineHeight": "{lineHeights.2}",
+            "fontSize": "{fontSize.2}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.none}",
+            "textDecoration": "{textDecoration.underline}"
+          },
+          "type": "typography",
+          "description": "600"
+        }
+      },
+      "16": {
+        "regular": {
+          "value": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-0}",
+            "lineHeight": "{lineHeights.2}",
+            "fontSize": "{fontSize.3}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.none}",
+            "textDecoration": "{textDecoration.none}"
+          },
+          "type": "typography",
+          "description": "400"
+        },
+        "regular-underline": {
+          "value": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-0}",
+            "lineHeight": "{lineHeights.2}",
+            "fontSize": "{fontSize.3}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.none}",
+            "textDecoration": "{textDecoration.underline}"
+          },
+          "type": "typography",
+          "description": "400"
+        },
+        "bold": {
+          "value": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-2}",
+            "lineHeight": "{lineHeights.2}",
+            "fontSize": "{fontSize.3}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.none}",
+            "textDecoration": "{textDecoration.none}"
+          },
+          "type": "typography",
+          "description": "700",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-1}",
+            "lineHeight": "{lineHeights.2}",
+            "fontSize": "{fontSize.3}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.none}",
+            "textDecoration": "{textDecoration.none}"
+          }
+        },
+        "bold-underline": {
+          "value": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-2}",
+            "lineHeight": "{lineHeights.2}",
+            "fontSize": "{fontSize.3}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.none}",
+            "textDecoration": "{textDecoration.underline}"
+          },
+          "type": "typography",
+          "description": "700",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-1}",
+            "lineHeight": "{lineHeights.2}",
+            "fontSize": "{fontSize.3}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.none}",
+            "textDecoration": "{textDecoration.underline}"
+          }
+        },
+        "semibold": {
+          "value": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-1}",
+            "lineHeight": "{lineHeights.2}",
+            "fontSize": "{fontSize.3}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.none}",
+            "textDecoration": "{textDecoration.none}"
+          },
+          "type": "typography",
+          "description": "600"
+        },
+        "semibold-underline": {
+          "value": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-1}",
+            "lineHeight": "{lineHeights.2}",
+            "fontSize": "{fontSize.3}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.none}",
+            "textDecoration": "{textDecoration.underline}"
+          },
+          "type": "typography",
+          "description": "600"
+        }
+      },
+      "18": {
+        "regular": {
+          "value": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-0}",
+            "lineHeight": "{lineHeights.2}",
+            "fontSize": "{fontSize.4}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.none}",
+            "textDecoration": "{textDecoration.none}"
+          },
+          "type": "typography",
+          "description": "400"
+        },
+        "regular-underline": {
+          "value": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-0}",
+            "lineHeight": "{lineHeights.2}",
+            "fontSize": "{fontSize.4}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.none}",
+            "textDecoration": "{textDecoration.underline}"
+          },
+          "type": "typography",
+          "description": "400"
+        },
+        "semibold": {
+          "value": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-1}",
+            "lineHeight": "{lineHeights.2}",
+            "fontSize": "{fontSize.4}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.none}",
+            "textDecoration": "{textDecoration.none}"
+          },
+          "type": "typography",
+          "description": "600"
+        },
+        "semibold-underline": {
+          "value": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-1}",
+            "lineHeight": "{lineHeights.2}",
+            "fontSize": "{fontSize.4}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.none}",
+            "textDecoration": "{textDecoration.underline}"
+          },
+          "type": "typography",
+          "description": "600"
+        },
+        "bold": {
+          "value": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-2}",
+            "lineHeight": "{lineHeights.2}",
+            "fontSize": "{fontSize.4}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.none}",
+            "textDecoration": "{textDecoration.none}"
+          },
+          "type": "typography",
+          "description": "700"
+        },
+        "bold-underline": {
+          "value": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-2}",
+            "lineHeight": "{lineHeights.2}",
+            "fontSize": "{fontSize.4}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.none}",
+            "textDecoration": "{textDecoration.underline}"
+          },
+          "type": "typography",
+          "description": "700"
+        }
+      }
+    },
+    "headline": {
+      "20": {
+        "light": {
+          "value": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-3}",
+            "lineHeight": "{lineHeights.3}",
+            "fontSize": "{fontSize.5}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.none}",
+            "textDecoration": "{textDecoration.none}"
+          },
+          "type": "typography",
+          "description": "300",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-2}",
+            "lineHeight": "{lineHeights.3}",
+            "fontSize": "{fontSize.4}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.none}",
+            "textDecoration": "{textDecoration.none}"
+          }
+        },
+        "light-underlne": {
+          "value": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-3}",
+            "lineHeight": "{lineHeights.3}",
+            "fontSize": "{fontSize.5}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.none}",
+            "textDecoration": "{textDecoration.underline}"
+          },
+          "type": "typography",
+          "description": "300",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-2}",
+            "lineHeight": "{lineHeights.3}",
+            "fontSize": "{fontSize.4}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.none}",
+            "textDecoration": "{textDecoration.underline}"
+          }
+        },
+        "regular": {
+          "value": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-0}",
+            "lineHeight": "{lineHeights.3}",
+            "fontSize": "{fontSize.5}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.none}",
+            "textDecoration": "{textDecoration.none}"
+          },
+          "type": "typography",
+          "description": "400",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-0}",
+            "lineHeight": "{lineHeights.3}",
+            "fontSize": "{fontSize.4}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.none}",
+            "textDecoration": "{textDecoration.none}"
+          }
+        },
+        "regular-underline": {
+          "value": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-0}",
+            "lineHeight": "{lineHeights.3}",
+            "fontSize": "{fontSize.5}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.none}",
+            "textDecoration": "{textDecoration.underline}"
+          },
+          "type": "typography",
+          "description": "400",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-0}",
+            "lineHeight": "{lineHeights.3}",
+            "fontSize": "{fontSize.4}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.none}",
+            "textDecoration": "{textDecoration.underline}"
+          }
+        },
+        "bold": {
+          "value": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-4}",
+            "lineHeight": "{lineHeights.3}",
+            "fontSize": "{fontSize.5}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.none}",
+            "textDecoration": "{textDecoration.none}"
+          },
+          "type": "typography",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-3}",
+            "lineHeight": "{lineHeights.3}",
+            "fontSize": "{fontSize.4}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.none}",
+            "textDecoration": "{textDecoration.none}"
+          },
+          "description": "900"
+        },
+        "bold-underlne": {
+          "value": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-4}",
+            "lineHeight": "{lineHeights.3}",
+            "fontSize": "{fontSize.5}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.none}",
+            "textDecoration": "{textDecoration.underline}"
+          },
+          "type": "typography",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-3}",
+            "lineHeight": "{lineHeights.3}",
+            "fontSize": "{fontSize.4}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.none}",
+            "textDecoration": "{textDecoration.underline}"
+          },
+          "description": "900"
+        }
+      },
+      "24": {
+        "light-underlne": {
+          "value": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-3}",
+            "lineHeight": "{lineHeights.4}",
+            "fontSize": "{fontSize.6}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.none}",
+            "textDecoration": "{textDecoration.underline}"
+          },
+          "type": "typography",
+          "description": "300",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-2}",
+            "lineHeight": "{lineHeights.4}",
+            "fontSize": "{fontSize.5}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.none}",
+            "textDecoration": "{textDecoration.underline}"
+          }
+        },
+        "regular": {
+          "value": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-0}",
+            "lineHeight": "{lineHeights.4}",
+            "fontSize": "{fontSize.6}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.none}",
+            "textDecoration": "{textDecoration.none}"
+          },
+          "type": "typography",
+          "description": "400",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-0}",
+            "lineHeight": "{lineHeights.4}",
+            "fontSize": "{fontSize.5}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.none}",
+            "textDecoration": "{textDecoration.none}"
+          }
+        },
+        "regular-underline": {
+          "value": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-0}",
+            "lineHeight": "{lineHeights.4}",
+            "fontSize": "{fontSize.6}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.none}",
+            "textDecoration": "{textDecoration.underline}"
+          },
+          "type": "typography",
+          "description": "400",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-0}",
+            "lineHeight": "{lineHeights.4}",
+            "fontSize": "{fontSize.5}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.none}",
+            "textDecoration": "{textDecoration.underline}"
+          }
+        },
+        "bold": {
+          "value": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-4}",
+            "lineHeight": "{lineHeights.4}",
+            "fontSize": "{fontSize.6}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.none}",
+            "textDecoration": "{textDecoration.none}"
+          },
+          "type": "typography",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-3}",
+            "lineHeight": "{lineHeights.4}",
+            "fontSize": "{fontSize.5}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.none}",
+            "textDecoration": "{textDecoration.none}"
+          },
+          "description": "900"
+        },
+        "bold-underlne": {
+          "value": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-4}",
+            "lineHeight": "{lineHeights.4}",
+            "fontSize": "{fontSize.6}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.none}",
+            "textDecoration": "{textDecoration.underline}"
+          },
+          "type": "typography",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-3}",
+            "lineHeight": "{lineHeights.4}",
+            "fontSize": "{fontSize.5}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.none}",
+            "textDecoration": "{textDecoration.underline}"
+          },
+          "description": "900"
+        },
+        "light": {
+          "value": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-3}",
+            "lineHeight": "{lineHeights.4}",
+            "fontSize": "{fontSize.6}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.none}",
+            "textDecoration": "{textDecoration.none}"
+          },
+          "type": "typography",
+          "description": "300",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-2}",
+            "lineHeight": "{lineHeights.4}",
+            "fontSize": "{fontSize.5}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.none}",
+            "textDecoration": "{textDecoration.none}"
+          }
+        }
+      },
+      "32": {
+        "light": {
+          "value": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-3}",
+            "lineHeight": "{lineHeights.5}",
+            "fontSize": "{fontSize.7}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.none}"
+          },
+          "type": "typography",
+          "description": "300",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-2}",
+            "lineHeight": "{lineHeights.5}",
+            "fontSize": "{fontSize.6}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.none}"
+          }
+        },
+        "light-underlne": {
+          "value": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-3}",
+            "lineHeight": "{lineHeights.5}",
+            "fontSize": "{fontSize.7}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.underline}"
+          },
+          "type": "typography",
+          "description": "300",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-2}",
+            "lineHeight": "{lineHeights.5}",
+            "fontSize": "{fontSize.6}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.underline}"
+          }
+        },
+        "regular-underline": {
+          "value": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-0}",
+            "lineHeight": "{lineHeights.5}",
+            "fontSize": "{fontSize.7}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.underline}"
+          },
+          "type": "typography",
+          "description": "400",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-0}",
+            "lineHeight": "{lineHeights.5}",
+            "fontSize": "{fontSize.6}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.underline}"
+          }
+        },
+        "regular": {
+          "value": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-0}",
+            "lineHeight": "{lineHeights.5}",
+            "fontSize": "{fontSize.7}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.none}"
+          },
+          "type": "typography",
+          "description": "400",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-0}",
+            "lineHeight": "{lineHeights.5}",
+            "fontSize": "{fontSize.6}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.none}"
+          }
+        },
+        "bold": {
+          "value": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-4}",
+            "lineHeight": "{lineHeights.5}",
+            "fontSize": "{fontSize.7}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.none}"
+          },
+          "type": "typography",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-3}",
+            "lineHeight": "{lineHeights.5}",
+            "fontSize": "{fontSize.6}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.none}"
+          },
+          "description": "900"
+        },
+        "bold-underlne": {
+          "value": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-4}",
+            "lineHeight": "{lineHeights.5}",
+            "fontSize": "{fontSize.7}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.underline}"
+          },
+          "type": "typography",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-3}",
+            "lineHeight": "{lineHeights.5}",
+            "fontSize": "{fontSize.6}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.underline}"
+          },
+          "description": "900"
+        }
+      },
+      "48": {
+        "light": {
+          "value": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-5}",
+            "lineHeight": "{lineHeights.6}",
+            "fontSize": "{fontSize.8}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.none}"
+          },
+          "type": "typography",
+          "description": "300",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-4}",
+            "lineHeight": "{lineHeights.6}",
+            "fontSize": "{fontSize.7}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.none}"
+          }
+        },
+        "light-underlne": {
+          "value": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-5}",
+            "lineHeight": "{lineHeights.6}",
+            "fontSize": "{fontSize.8}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.underline}"
+          },
+          "type": "typography",
+          "description": "300",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-4}",
+            "lineHeight": "{lineHeights.6}",
+            "fontSize": "{fontSize.7}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.underline}"
+          }
+        },
+        "regular": {
+          "value": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-0}",
+            "lineHeight": "{lineHeights.6}",
+            "fontSize": "{fontSize.8}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.none}"
+          },
+          "type": "typography",
+          "description": "400",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-0}",
+            "lineHeight": "{lineHeights.6}",
+            "fontSize": "{fontSize.7}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.none}"
+          }
+        },
+        "regular-underline": {
+          "value": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-0}",
+            "lineHeight": "{lineHeights.6}",
+            "fontSize": "{fontSize.8}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.underline}"
+          },
+          "type": "typography",
+          "description": "400",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-0}",
+            "lineHeight": "{lineHeights.6}",
+            "fontSize": "{fontSize.7}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.underline}"
+          }
+        },
+        "bold": {
+          "value": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-4}",
+            "lineHeight": "{lineHeights.6}",
+            "fontSize": "{fontSize.8}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.none}"
+          },
+          "type": "typography",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-3}",
+            "lineHeight": "{lineHeights.6}",
+            "fontSize": "{fontSize.7}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.none}"
+          },
+          "description": "900"
+        },
+        "bold-underlne": {
+          "value": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-4}",
+            "lineHeight": "{lineHeights.6}",
+            "fontSize": "{fontSize.8}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.underline}"
+          },
+          "type": "typography",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-3}",
+            "lineHeight": "{lineHeights.6}",
+            "fontSize": "{fontSize.7}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.underline}"
+          },
+          "description": "900"
+        }
+      }
+    },
+    "display": {
+      "56": {
+        "light": {
+          "value": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-5}",
+            "lineHeight": "{lineHeights.7}",
+            "fontSize": "{fontSize.9}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.none}"
+          },
+          "type": "typography",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-4}",
+            "lineHeight": "{lineHeights.7}",
+            "fontSize": "{fontSize.8}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.none}"
+          },
+          "description": "200"
+        },
+        "light-underline": {
+          "value": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-5}",
+            "lineHeight": "{lineHeights.7}",
+            "fontSize": "{fontSize.9}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.underline}"
+          },
+          "type": "typography",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-4}",
+            "lineHeight": "{lineHeights.7}",
+            "fontSize": "{fontSize.8}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.underline}"
+          },
+          "description": "200"
+        },
+        "regular": {
+          "value": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-0}",
+            "lineHeight": "{lineHeights.7}",
+            "fontSize": "{fontSize.9}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.none}"
+          },
+          "type": "typography",
+          "description": "400",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-0}",
+            "lineHeight": "{lineHeights.7}",
+            "fontSize": "{fontSize.8}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.none}"
+          }
+        },
+        "regular-underline": {
+          "value": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-0}",
+            "lineHeight": "{lineHeights.7}",
+            "fontSize": "{fontSize.9}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.underline}"
+          },
+          "type": "typography",
+          "description": "400",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-0}",
+            "lineHeight": "{lineHeights.7}",
+            "fontSize": "{fontSize.8}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.underline}"
+          }
+        },
+        "bold": {
+          "value": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-4}",
+            "lineHeight": "{lineHeights.7}",
+            "fontSize": "{fontSize.9}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.none}"
+          },
+          "type": "typography",
+          "description": "700",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-3}",
+            "lineHeight": "{lineHeights.7}",
+            "fontSize": "{fontSize.8}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.none}"
+          }
+        },
+        "bold-underline": {
+          "value": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-4}",
+            "lineHeight": "{lineHeights.7}",
+            "fontSize": "{fontSize.9}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.underline}"
+          },
+          "type": "typography",
+          "description": "700",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-3}",
+            "lineHeight": "{lineHeights.7}",
+            "fontSize": "{fontSize.8}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.underline}"
+          }
+        }
+      },
+      "72": {
+        "light": {
+          "value": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-5}",
+            "lineHeight": "{lineHeights.8}",
+            "fontSize": "{fontSize.10}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.none}"
+          },
+          "type": "typography",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-4}",
+            "lineHeight": "{lineHeights.8}",
+            "fontSize": "{fontSize.9}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.none}"
+          },
+          "description": "200"
+        },
+        "light-underline": {
+          "value": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-5}",
+            "lineHeight": "{lineHeights.8}",
+            "fontSize": "{fontSize.10}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.underline}"
+          },
+          "type": "typography",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-4}",
+            "lineHeight": "{lineHeights.8}",
+            "fontSize": "{fontSize.9}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.underline}"
+          },
+          "description": "200"
+        },
+        "regular": {
+          "value": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-0}",
+            "lineHeight": "{lineHeights.8}",
+            "fontSize": "{fontSize.10}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.none}"
+          },
+          "type": "typography",
+          "description": "400",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-0}",
+            "lineHeight": "{lineHeights.8}",
+            "fontSize": "{fontSize.9}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.none}"
+          }
+        },
+        "regular-underline": {
+          "value": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-0}",
+            "lineHeight": "{lineHeights.8}",
+            "fontSize": "{fontSize.10}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.underline}"
+          },
+          "type": "typography",
+          "description": "400",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-0}",
+            "lineHeight": "{lineHeights.8}",
+            "fontSize": "{fontSize.9}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.underline}"
+          }
+        },
+        "bold-underline": {
+          "value": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-4}",
+            "lineHeight": "{lineHeights.8}",
+            "fontSize": "{fontSize.10}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.underline}"
+          },
+          "type": "typography",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-3}",
+            "lineHeight": "{lineHeights.8}",
+            "fontSize": "{fontSize.9}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.underline}"
+          },
+          "description": "900"
+        },
+        "bold": {
+          "value": {
+            "fontFamily": "{fontFamilies.montserrat}",
+            "fontWeight": "{fontWeights.montserrat-3}",
+            "lineHeight": "{lineHeights.8}",
+            "fontSize": "{fontSize.9}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.none}"
+          },
+          "type": "typography",
+          "description": "900"
+        }
+      }
+    }
+  },
+  "noto sans lao looped": {
+    "body": {
+      "10": {
+        "regular": {
+          "value": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-6}",
+            "lineHeight": "{lineHeights.0}",
+            "fontSize": "{fontSize.0}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.none}"
+          },
+          "type": "typography",
+          "description": "Noto Sans Lao Looped",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-5}",
+            "lineHeight": "{lineHeights.0}",
+            "fontSize": "{fontSize.0}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.none}"
+          }
+        },
+        "regular-underline": {
+          "value": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-6}",
+            "lineHeight": "{lineHeights.0}",
+            "fontSize": "{fontSize.0}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.underline}"
+          },
+          "type": "typography",
+          "description": "Noto Sans Lao Looped",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-5}",
+            "lineHeight": "{lineHeights.0}",
+            "fontSize": "{fontSize.0}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.underline}"
+          }
+        },
+        "bold": {
+          "value": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-7}",
+            "lineHeight": "{lineHeights.0}",
+            "fontSize": "{fontSize.0}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.none}"
+          },
+          "type": "typography",
+          "description": "Noto Sans Lao Looped",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-6}",
+            "lineHeight": "{lineHeights.0}",
+            "fontSize": "{fontSize.0}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.none}"
+          }
+        },
+        "bold-underline": {
+          "value": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-7}",
+            "lineHeight": "{lineHeights.0}",
+            "fontSize": "{fontSize.0}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.underline}"
+          },
+          "type": "typography",
+          "description": "Noto Sans Lao Looped",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-6}",
+            "lineHeight": "{lineHeights.0}",
+            "fontSize": "{fontSize.0}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.underline}"
+          }
+        }
+      },
+      "12": {
+        "regular": {
+          "value": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-6}",
+            "lineHeight": "{lineHeights.1}",
+            "fontSize": "{fontSize.1}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.none}"
+          },
+          "type": "typography",
+          "description": "Noto Sans Lao Looped",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-5}",
+            "lineHeight": "{lineHeights.1}",
+            "fontSize": "{fontSize.1}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.none}"
+          }
+        },
+        "regular-underline": {
+          "value": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-6}",
+            "lineHeight": "{lineHeights.1}",
+            "fontSize": "{fontSize.1}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.underline}"
+          },
+          "type": "typography",
+          "description": "Noto Sans Lao Looped",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-5}",
+            "lineHeight": "{lineHeights.1}",
+            "fontSize": "{fontSize.1}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.underline}"
+          }
+        },
+        "bold": {
+          "value": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-7}",
+            "lineHeight": "{lineHeights.1}",
+            "fontSize": "{fontSize.1}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.none}"
+          },
+          "type": "typography",
+          "description": "Noto Sans Lao Looped",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-6}",
+            "lineHeight": "{lineHeights.1}",
+            "fontSize": "{fontSize.1}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.none}"
+          }
+        },
+        "bold-underline": {
+          "value": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-7}",
+            "lineHeight": "{lineHeights.1}",
+            "fontSize": "{fontSize.1}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.underline}"
+          },
+          "type": "typography",
+          "description": "Noto Sans Lao Looped",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-6}",
+            "lineHeight": "{lineHeights.1}",
+            "fontSize": "{fontSize.1}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.underline}"
+          }
+        }
+      },
+      "14": {
+        "regular": {
+          "value": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-6}",
+            "lineHeight": "{lineHeights.2}",
+            "fontSize": "{fontSize.2}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.none}"
+          },
+          "type": "typography",
+          "description": "Noto Sans Lao Looped",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-5}",
+            "lineHeight": "{lineHeights.2}",
+            "fontSize": "{fontSize.2}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.none}"
+          }
+        },
+        "regular-underline": {
+          "value": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-6}",
+            "lineHeight": "{lineHeights.2}",
+            "fontSize": "{fontSize.2}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.underline}"
+          },
+          "type": "typography",
+          "description": "Noto Sans Lao Looped",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-5}",
+            "lineHeight": "{lineHeights.2}",
+            "fontSize": "{fontSize.2}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.underline}"
+          }
+        },
+        "bold": {
+          "value": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-7}",
+            "lineHeight": "{lineHeights.2}",
+            "fontSize": "{fontSize.2}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.none}"
+          },
+          "type": "typography",
+          "description": "Noto Sans Lao Looped",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-6}",
+            "lineHeight": "{lineHeights.2}",
+            "fontSize": "{fontSize.2}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.none}"
+          }
+        },
+        "bold-underline": {
+          "value": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-7}",
+            "lineHeight": "{lineHeights.2}",
+            "fontSize": "{fontSize.2}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.underline}"
+          },
+          "type": "typography",
+          "description": "Noto Sans Lao Looped",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-6}",
+            "lineHeight": "{lineHeights.2}",
+            "fontSize": "{fontSize.2}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.underline}"
+          }
+        }
+      },
+      "16": {
+        "regular": {
+          "value": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-6}",
+            "lineHeight": "{lineHeights.2}",
+            "fontSize": "{fontSize.3}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.none}"
+          },
+          "type": "typography",
+          "description": "Noto Sans Lao Looped",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-5}",
+            "lineHeight": "{lineHeights.2}",
+            "fontSize": "{fontSize.3}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.none}"
+          }
+        },
+        "regular-underline": {
+          "value": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-6}",
+            "lineHeight": "{lineHeights.2}",
+            "fontSize": "{fontSize.3}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.underline}"
+          },
+          "type": "typography",
+          "description": "Noto Sans Lao Looped",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-5}",
+            "lineHeight": "{lineHeights.2}",
+            "fontSize": "{fontSize.3}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.underline}"
+          }
+        },
+        "bold": {
+          "value": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-7}",
+            "lineHeight": "{lineHeights.2}",
+            "fontSize": "{fontSize.3}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.none}"
+          },
+          "type": "typography",
+          "description": "Noto Sans Lao Looped",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-6}",
+            "lineHeight": "{lineHeights.2}",
+            "fontSize": "{fontSize.3}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.none}"
+          }
+        },
+        "bold-underline": {
+          "value": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-7}",
+            "lineHeight": "{lineHeights.2}",
+            "fontSize": "{fontSize.3}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.underline}"
+          },
+          "type": "typography",
+          "description": "Noto Sans Lao Looped",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-6}",
+            "lineHeight": "{lineHeights.2}",
+            "fontSize": "{fontSize.3}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.underline}"
+          }
+        }
+      }
+    },
+    "headline": {
+      "20": {
+        "light": {
+          "value": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-8}",
+            "lineHeight": "{lineHeights.3}",
+            "fontSize": "{fontSize.5}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.none}"
+          },
+          "type": "typography",
+          "description": "Noto Sans Lao Looped",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-7}",
+            "lineHeight": "{lineHeights.3}",
+            "fontSize": "{fontSize.4}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.none}"
+          }
+        },
+        "light-underline": {
+          "value": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-8}",
+            "lineHeight": "{lineHeights.3}",
+            "fontSize": "{fontSize.5}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.underline}"
+          },
+          "type": "typography",
+          "description": "Noto Sans Lao Looped",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-7}",
+            "lineHeight": "{lineHeights.3}",
+            "fontSize": "{fontSize.4}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.underline}"
+          }
+        },
+        "regular": {
+          "value": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-6}",
+            "lineHeight": "{lineHeights.3}",
+            "fontSize": "{fontSize.5}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.none}"
+          },
+          "type": "typography",
+          "description": "Noto Sans Lao Looped",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-5}",
+            "lineHeight": "{lineHeights.3}",
+            "fontSize": "{fontSize.4}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.none}"
+          }
+        },
+        "regular-underline": {
+          "value": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-6}",
+            "lineHeight": "{lineHeights.3}",
+            "fontSize": "{fontSize.5}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.underline}"
+          },
+          "type": "typography",
+          "description": "Noto Sans Lao Looped",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-5}",
+            "lineHeight": "{lineHeights.3}",
+            "fontSize": "{fontSize.4}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.underline}"
+          }
+        },
+        "bold": {
+          "value": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-9}",
+            "lineHeight": "{lineHeights.3}",
+            "fontSize": "{fontSize.5}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.none}"
+          },
+          "type": "typography",
+          "description": "Noto Sans Lao Looped",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-8}",
+            "lineHeight": "{lineHeights.3}",
+            "fontSize": "{fontSize.4}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.none}"
+          }
+        },
+        "bold-underline": {
+          "value": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-9}",
+            "lineHeight": "{lineHeights.3}",
+            "fontSize": "{fontSize.5}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.underline}"
+          },
+          "type": "typography",
+          "description": "Noto Sans Lao Looped",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-8}",
+            "lineHeight": "{lineHeights.3}",
+            "fontSize": "{fontSize.4}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.underline}"
+          }
+        }
+      },
+      "24": {
+        "light": {
+          "value": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-8}",
+            "lineHeight": "{lineHeights.4}",
+            "fontSize": "{fontSize.6}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.none}"
+          },
+          "type": "typography",
+          "description": "Noto Sans Lao Looped",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-7}",
+            "lineHeight": "{lineHeights.4}",
+            "fontSize": "{fontSize.5}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.none}"
+          }
+        },
+        "light-underline": {
+          "value": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-8}",
+            "lineHeight": "{lineHeights.4}",
+            "fontSize": "{fontSize.6}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.underline}"
+          },
+          "type": "typography",
+          "description": "Noto Sans Lao Looped",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-7}",
+            "lineHeight": "{lineHeights.4}",
+            "fontSize": "{fontSize.5}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.underline}"
+          }
+        },
+        "regular": {
+          "value": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-6}",
+            "lineHeight": "{lineHeights.4}",
+            "fontSize": "{fontSize.6}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.none}"
+          },
+          "type": "typography",
+          "description": "Noto Sans Lao Looped",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-5}",
+            "lineHeight": "{lineHeights.4}",
+            "fontSize": "{fontSize.5}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.none}"
+          }
+        },
+        "regular-underline": {
+          "value": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-6}",
+            "lineHeight": "{lineHeights.4}",
+            "fontSize": "{fontSize.6}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.underline}"
+          },
+          "type": "typography",
+          "description": "Noto Sans Lao Looped",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-5}",
+            "lineHeight": "{lineHeights.4}",
+            "fontSize": "{fontSize.5}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.underline}"
+          }
+        },
+        "bold": {
+          "value": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-9}",
+            "lineHeight": "{lineHeights.4}",
+            "fontSize": "{fontSize.6}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.none}"
+          },
+          "type": "typography",
+          "description": "Noto Sans Lao Looped",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-8}",
+            "lineHeight": "{lineHeights.4}",
+            "fontSize": "{fontSize.5}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.none}"
+          }
+        },
+        "bold-underline": {
+          "value": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-9}",
+            "lineHeight": "{lineHeights.4}",
+            "fontSize": "{fontSize.6}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.underline}"
+          },
+          "type": "typography",
+          "description": "Noto Sans Lao Looped",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-8}",
+            "lineHeight": "{lineHeights.4}",
+            "fontSize": "{fontSize.5}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.underline}"
+          }
+        }
+      },
+      "32": {
+        "light": {
+          "value": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-8}",
+            "lineHeight": "{lineHeights.5}",
+            "fontSize": "{fontSize.7}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.none}"
+          },
+          "type": "typography",
+          "description": "Noto Sans Lao Looped",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-7}",
+            "lineHeight": "{lineHeights.5}",
+            "fontSize": "{fontSize.6}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.none}"
+          }
+        },
+        "light-underline": {
+          "value": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-8}",
+            "lineHeight": "{lineHeights.5}",
+            "fontSize": "{fontSize.7}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.underline}"
+          },
+          "type": "typography",
+          "description": "Noto Sans Lao Looped",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-7}",
+            "lineHeight": "{lineHeights.5}",
+            "fontSize": "{fontSize.6}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.underline}"
+          }
+        },
+        "regular": {
+          "value": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-6}",
+            "lineHeight": "{lineHeights.5}",
+            "fontSize": "{fontSize.7}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.none}"
+          },
+          "type": "typography",
+          "description": "Noto Sans Lao Looped",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-5}",
+            "lineHeight": "{lineHeights.5}",
+            "fontSize": "{fontSize.6}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.none}"
+          }
+        },
+        "regular-underline": {
+          "value": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-6}",
+            "lineHeight": "{lineHeights.5}",
+            "fontSize": "{fontSize.7}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.underline}"
+          },
+          "type": "typography",
+          "description": "Noto Sans Lao Looped",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-5}",
+            "lineHeight": "{lineHeights.5}",
+            "fontSize": "{fontSize.6}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.underline}"
+          }
+        },
+        "bold": {
+          "value": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-9}",
+            "lineHeight": "{lineHeights.5}",
+            "fontSize": "{fontSize.7}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.none}"
+          },
+          "type": "typography",
+          "description": "Noto Sans Lao Looped",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-8}",
+            "lineHeight": "{lineHeights.5}",
+            "fontSize": "{fontSize.6}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.none}"
+          }
+        },
+        "bold-underline": {
+          "value": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-9}",
+            "lineHeight": "{lineHeights.5}",
+            "fontSize": "{fontSize.7}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.underline}"
+          },
+          "type": "typography",
+          "description": "Noto Sans Lao Looped",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-8}",
+            "lineHeight": "{lineHeights.5}",
+            "fontSize": "{fontSize.6}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.underline}"
+          }
+        }
+      },
+      "48": {
+        "light": {
+          "value": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-10}",
+            "lineHeight": "{lineHeights.6}",
+            "fontSize": "{fontSize.8}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.none}"
+          },
+          "type": "typography",
+          "description": "Noto Sans Lao Looped",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-9}",
+            "lineHeight": "{lineHeights.6}",
+            "fontSize": "{fontSize.7}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.none}"
+          }
+        },
+        "light-underline": {
+          "value": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-10}",
+            "lineHeight": "{lineHeights.6}",
+            "fontSize": "{fontSize.8}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.underline}"
+          },
+          "type": "typography",
+          "description": "Noto Sans Lao Looped",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-9}",
+            "lineHeight": "{lineHeights.6}",
+            "fontSize": "{fontSize.7}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.underline}"
+          }
+        },
+        "regular": {
+          "value": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-6}",
+            "lineHeight": "{lineHeights.6}",
+            "fontSize": "{fontSize.8}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.none}"
+          },
+          "type": "typography",
+          "description": "Noto Sans Lao Looped",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-5}",
+            "lineHeight": "{lineHeights.6}",
+            "fontSize": "{fontSize.7}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.none}"
+          }
+        },
+        "regular-underline": {
+          "value": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-6}",
+            "lineHeight": "{lineHeights.6}",
+            "fontSize": "{fontSize.8}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.underline}"
+          },
+          "type": "typography",
+          "description": "Noto Sans Lao Looped",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-5}",
+            "lineHeight": "{lineHeights.6}",
+            "fontSize": "{fontSize.7}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.underline}"
+          }
+        },
+        "bold": {
+          "value": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-9}",
+            "lineHeight": "{lineHeights.6}",
+            "fontSize": "{fontSize.8}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.none}"
+          },
+          "type": "typography",
+          "description": "Noto Sans Lao Looped",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-8}",
+            "lineHeight": "{lineHeights.6}",
+            "fontSize": "{fontSize.7}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.none}"
+          }
+        },
+        "bold-underline": {
+          "value": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-9}",
+            "lineHeight": "{lineHeights.6}",
+            "fontSize": "{fontSize.8}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.underline}"
+          },
+          "type": "typography",
+          "description": "Noto Sans Lao Looped",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-8}",
+            "lineHeight": "{lineHeights.6}",
+            "fontSize": "{fontSize.7}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.underline}"
+          }
+        }
+      }
+    },
+    "display": {
+      "56": {
+        "light": {
+          "value": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-10}",
+            "lineHeight": "{lineHeights.7}",
+            "fontSize": "{fontSize.9}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.none}"
+          },
+          "type": "typography",
+          "description": "Noto Sans Lao Looped",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-9}",
+            "lineHeight": "{lineHeights.7}",
+            "fontSize": "{fontSize.8}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.none}"
+          }
+        },
+        "light-underline": {
+          "value": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-10}",
+            "lineHeight": "{lineHeights.7}",
+            "fontSize": "{fontSize.9}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.underline}"
+          },
+          "type": "typography",
+          "description": "Noto Sans Lao Looped",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-9}",
+            "lineHeight": "{lineHeights.7}",
+            "fontSize": "{fontSize.8}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.underline}"
+          }
+        },
+        "regular": {
+          "value": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-6}",
+            "lineHeight": "{lineHeights.7}",
+            "fontSize": "{fontSize.9}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.none}"
+          },
+          "type": "typography",
+          "description": "Noto Sans Lao Looped",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-5}",
+            "lineHeight": "{lineHeights.7}",
+            "fontSize": "{fontSize.8}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.none}"
+          }
+        },
+        "regular-underline": {
+          "value": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-6}",
+            "lineHeight": "{lineHeights.7}",
+            "fontSize": "{fontSize.9}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.underline}"
+          },
+          "type": "typography",
+          "description": "Noto Sans Lao Looped",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-5}",
+            "lineHeight": "{lineHeights.7}",
+            "fontSize": "{fontSize.8}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.underline}"
+          }
+        },
+        "bold": {
+          "value": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-9}",
+            "lineHeight": "{lineHeights.7}",
+            "fontSize": "{fontSize.9}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.none}"
+          },
+          "type": "typography",
+          "description": "Noto Sans Lao Looped",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-8}",
+            "lineHeight": "{lineHeights.7}",
+            "fontSize": "{fontSize.8}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.none}"
+          }
+        },
+        "bold-underline": {
+          "value": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-9}",
+            "lineHeight": "{lineHeights.7}",
+            "fontSize": "{fontSize.9}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.underline}"
+          },
+          "type": "typography",
+          "description": "Noto Sans Lao Looped",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-8}",
+            "lineHeight": "{lineHeights.7}",
+            "fontSize": "{fontSize.8}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.underline}"
+          }
+        }
+      },
+      "72": {
+        "light": {
+          "value": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-10}",
+            "lineHeight": "{lineHeights.8}",
+            "fontSize": "{fontSize.10}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.none}"
+          },
+          "type": "typography",
+          "description": "Noto Sans Lao Looped",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-9}",
+            "lineHeight": "{lineHeights.8}",
+            "fontSize": "{fontSize.9}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.none}"
+          }
+        },
+        "light-underline": {
+          "value": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-10}",
+            "lineHeight": "{lineHeights.8}",
+            "fontSize": "{fontSize.10}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.underline}"
+          },
+          "type": "typography",
+          "description": "Noto Sans Lao Looped",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-9}",
+            "lineHeight": "{lineHeights.8}",
+            "fontSize": "{fontSize.9}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.underline}"
+          }
+        },
+        "regular": {
+          "value": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-6}",
+            "lineHeight": "{lineHeights.8}",
+            "fontSize": "{fontSize.10}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.none}"
+          },
+          "type": "typography",
+          "description": "Noto Sans Lao Looped",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-5}",
+            "lineHeight": "{lineHeights.8}",
+            "fontSize": "{fontSize.9}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.none}"
+          }
+        },
+        "regular-underline": {
+          "value": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-6}",
+            "lineHeight": "{lineHeights.8}",
+            "fontSize": "{fontSize.10}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.underline}"
+          },
+          "type": "typography",
+          "description": "Noto Sans Lao Looped",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-5}",
+            "lineHeight": "{lineHeights.8}",
+            "fontSize": "{fontSize.9}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.underline}"
+          }
+        },
+        "bold": {
+          "value": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-9}",
+            "lineHeight": "{lineHeights.8}",
+            "fontSize": "{fontSize.10}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.none}"
+          },
+          "type": "typography",
+          "description": "Noto Sans Lao Looped",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-8}",
+            "lineHeight": "{lineHeights.8}",
+            "fontSize": "{fontSize.9}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.none}"
+          }
+        },
+        "bold-underline": {
+          "value": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-9}",
+            "lineHeight": "{lineHeights.8}",
+            "fontSize": "{fontSize.10}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.underline}"
+          },
+          "type": "typography",
+          "description": "Noto Sans Lao Looped",
+          "oldValue": {
+            "fontFamily": "{fontFamilies.noto-sans-lao-looped}",
+            "fontWeight": "{fontWeights.noto-sans-lao-looped-8}",
+            "lineHeight": "{lineHeights.8}",
+            "fontSize": "{fontSize.9}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.uppercase}",
+            "textDecoration": "{textDecoration.underline}"
+          }
+        }
+      }
+    }
+  },
+  "textCase": {
+    "none": {
+      "value": "none",
+      "type": "textCase"
+    },
+    "uppercase": {
+      "value": "uppercase",
+      "type": "textCase"
+    }
+  },
+  "textDecoration": {
+    "none": {
+      "value": "none",
+      "type": "textDecoration"
+    },
+    "underline": {
+      "value": "underline",
+      "type": "textDecoration"
+    }
+  },
+  "paragraphIndent": {
+    "0": {
+      "value": "0px",
+      "type": "dimension"
+    }
+  },
+  "fontFamilies": {
+    "montserrat": {
+      "value": "Montserrat",
+      "type": "fontFamilies"
+    },
+    "noto-sans-lao-looped": {
+      "value": "Noto Sans Lao Looped",
+      "type": "fontFamilies"
+    }
+  },
+  "colors": {
+    "content": {
+      "100": {
+        "value": "#ffffff",
+        "type": "color",
+        "parent": "global/Value",
+        "description": ""
+      },
+      "500": {
+        "value": "#212833",
+        "type": "color",
+        "parent": "global/Value",
+        "description": ""
+      },
+      "900": {
+        "value": "#000000",
+        "type": "color",
+        "parent": "global/Value",
+        "description": ""
+      }
+    },
+    "neutral": {
+      "50": {
+        "value": "#f7f8f8",
+        "type": "color",
+        "parent": "global/Value",
+        "description": ""
+      },
+      "100": {
+        "value": "#eff1f1",
+        "type": "color",
+        "parent": "global/Value",
+        "description": ""
+      },
+      "200": {
+        "value": "#dde1e0",
+        "type": "color",
+        "parent": "global/Value",
+        "description": ""
+      },
+      "300": {
+        "value": "#bbc3c2",
+        "type": "color",
+        "parent": "global/Value",
+        "description": ""
+      },
+      "400": {
+        "value": "#9aa6a5",
+        "type": "color",
+        "parent": "global/Value",
+        "description": ""
+      },
+      "500": {
+        "value": "#7b8a88",
+        "type": "color",
+        "parent": "global/Value",
+        "description": ""
+      },
+      "600": {
+        "value": "#5c6f6c",
+        "type": "color",
+        "parent": "global/Value",
+        "description": ""
+      },
+      "700": {
+        "value": "#3f5552",
+        "type": "color",
+        "parent": "global/Value",
+        "description": ""
+      },
+      "800": {
+        "value": "#233c39",
+        "type": "color",
+        "parent": "global/Value",
+        "description": ""
+      },
+      "900": {
+        "value": "#132321",
+        "type": "color",
+        "parent": "global/Value",
+        "description": ""
+      }
+    },
+    "blue": {
+      "50": {
+        "value": "#ebf4ff",
+        "type": "color",
+        "parent": "global/Value",
+        "description": "",
+        "oldValue": "#f6fafd"
+      },
+      "100": {
+        "value": "#d9eaff",
+        "type": "color",
+        "parent": "global/Value",
+        "description": "",
+        "oldValue": "#eff1f1"
+      },
+      "200": {
+        "value": "#b2d4ff",
+        "type": "color",
+        "parent": "global/Value",
+        "description": "",
+        "oldValue": "#cfe1f7"
+      },
+      "300": {
+        "value": "#80b8ff",
+        "type": "color",
+        "parent": "global/Value",
+        "description": "",
+        "oldValue": "#9fc4ef"
+      },
+      "400": {
+        "value": "#4094ff",
+        "type": "color",
+        "parent": "global/Value",
+        "description": "",
+        "oldValue": "#6ea5e8"
+      },
+      "500": {
+        "value": "#0071ff",
+        "type": "color",
+        "parent": "global/Value",
+        "description": "",
+        "oldValue": "#3c87df"
+      },
+      "600": {
+        "value": "#0060d9",
+        "type": "color",
+        "parent": "global/Value",
+        "description": "",
+        "oldValue": "#2e6ab2"
+      },
+      "700": {
+        "value": "#0049a6",
+        "type": "color",
+        "parent": "global/Value",
+        "description": "",
+        "oldValue": "#234f85"
+      },
+      "800": {
+        "value": "#003880",
+        "type": "color",
+        "parent": "global/Value",
+        "description": "",
+        "oldValue": "#18365b"
+      },
+      "900": {
+        "value": "#002759",
+        "type": "color",
+        "parent": "global/Value",
+        "description": "",
+        "oldValue": "#0d1e33"
+      }
+    },
+    "pink": {
+      "50": {
+        "value": "#fef5fc",
+        "type": "color",
+        "parent": "global/Value",
+        "description": ""
+      },
+      "100": {
+        "value": "#fef1fa",
+        "type": "color",
+        "parent": "global/Value",
+        "description": ""
+      },
+      "200": {
+        "value": "#fddff3",
+        "type": "color",
+        "parent": "global/Value",
+        "description": ""
+      },
+      "300": {
+        "value": "#fbbfe7",
+        "type": "color",
+        "parent": "global/Value",
+        "description": ""
+      },
+      "400": {
+        "value": "#fa9eda",
+        "type": "color",
+        "parent": "global/Value",
+        "description": ""
+      },
+      "500": {
+        "value": "#f87ece",
+        "type": "color",
+        "parent": "global/Value",
+        "description": ""
+      },
+      "600": {
+        "value": "#db62b2",
+        "type": "color",
+        "parent": "global/Value",
+        "description": ""
+      },
+      "700": {
+        "value": "#a54985",
+        "type": "color",
+        "parent": "global/Value",
+        "description": ""
+      },
+      "800": {
+        "value": "#6e3159",
+        "type": "color",
+        "parent": "global/Value",
+        "description": ""
+      },
+      "900": {
+        "value": "#ffffff",
+        "type": "color",
+        "parent": "global/Value",
+        "description": ""
+      }
+    },
+    "teal": {
+      "50": {
+        "value": "#f7fdfc",
+        "type": "color",
+        "parent": "global/Value",
+        "description": ""
+      },
+      "100": {
+        "value": "#ecf9f8",
+        "type": "color",
+        "parent": "global/Value",
+        "description": ""
+      },
+      "200": {
+        "value": "#d5f1f0",
+        "type": "color",
+        "parent": "global/Value",
+        "description": ""
+      },
+      "300": {
+        "value": "#aae3e1",
+        "type": "color",
+        "parent": "global/Value",
+        "description": ""
+      },
+      "400": {
+        "value": "#80d4d2",
+        "type": "color",
+        "parent": "global/Value",
+        "description": ""
+      },
+      "500": {
+        "value": "#55c6c4",
+        "type": "color",
+        "parent": "global/Value",
+        "description": ""
+      },
+      "600": {
+        "value": "#39aaa7",
+        "type": "color",
+        "parent": "global/Value",
+        "description": ""
+      },
+      "700": {
+        "value": "#2b7f7d",
+        "type": "color",
+        "parent": "global/Value",
+        "description": ""
+      },
+      "800": {
+        "value": "#1c5553",
+        "type": "color",
+        "parent": "global/Value",
+        "description": ""
+      },
+      "900": {
+        "value": "#0e2a2a",
+        "type": "color",
+        "parent": "global/Value",
+        "description": ""
+      }
+    },
+    "purple": {
+      "50": {
+        "value": "#faf7fd",
+        "type": "color",
+        "parent": "global/Value",
+        "description": ""
+      },
+      "100": {
+        "value": "#f5f0fb",
+        "type": "color",
+        "parent": "global/Value",
+        "description": ""
+      },
+      "200": {
+        "value": "#e9ddf6",
+        "type": "color",
+        "parent": "global/Value",
+        "description": ""
+      },
+      "300": {
+        "value": "#d2baee",
+        "type": "color",
+        "parent": "global/Value",
+        "description": ""
+      },
+      "400": {
+        "value": "#bc98e5",
+        "type": "color",
+        "parent": "global/Value",
+        "description": ""
+      },
+      "500": {
+        "value": "#a575dc",
+        "type": "color",
+        "parent": "global/Value",
+        "description": ""
+      },
+      "600": {
+        "value": "#8959c0",
+        "type": "color",
+        "parent": "global/Value",
+        "description": ""
+      },
+      "700": {
+        "value": "#674390",
+        "type": "color",
+        "parent": "global/Value",
+        "description": ""
+      },
+      "800": {
+        "value": "#442c60",
+        "type": "color",
+        "parent": "global/Value",
+        "description": ""
+      },
+      "900": {
+        "value": "#221630",
+        "type": "color",
+        "parent": "global/Value",
+        "description": ""
+      }
+    },
+    "green": {
+      "50": {
+        "value": "#f0fdf4",
+        "type": "color",
+        "parent": "global/Value",
+        "description": "",
+        "oldValue": "#f9fcf8"
+      },
+      "100": {
+        "value": "#dcfce7",
+        "type": "color",
+        "parent": "global/Value",
+        "description": "",
+        "oldValue": "#eff8ec"
+      },
+      "200": {
+        "value": "#bbf7d0",
+        "type": "color",
+        "parent": "global/Value",
+        "description": "",
+        "oldValue": "#dbf0d5"
+      },
+      "300": {
+        "value": "#86efac",
+        "type": "color",
+        "parent": "global/Value",
+        "description": "",
+        "oldValue": "#b7e1ac"
+      },
+      "400": {
+        "value": "#4ade80",
+        "type": "color",
+        "parent": "global/Value",
+        "description": "",
+        "oldValue": "#92d282"
+      },
+      "500": {
+        "value": "#22c55e",
+        "type": "color",
+        "parent": "global/Value",
+        "description": "",
+        "oldValue": "#6ec458"
+      },
+      "600": {
+        "value": "#16a34a",
+        "type": "color",
+        "parent": "global/Value",
+        "description": "",
+        "oldValue": "#52a73b"
+      },
+      "700": {
+        "value": "#15803d",
+        "type": "color",
+        "parent": "global/Value",
+        "description": "",
+        "oldValue": "#3d7d2d"
+      },
+      "800": {
+        "value": "#166534",
+        "type": "color",
+        "parent": "global/Value",
+        "description": "",
+        "oldValue": "#29531e"
+      },
+      "900": {
+        "value": "#171717",
+        "type": "color",
+        "parent": "global/Value",
+        "description": "",
+        "oldValue": "#142a0f"
+      }
+    },
+    "yellow": {
+      "50": {
+        "value": "#fffcf5",
+        "type": "color",
+        "parent": "global/Value",
+        "description": ""
+      },
+      "100": {
+        "value": "#fff9eb",
+        "type": "color",
+        "parent": "global/Value",
+        "description": ""
+      },
+      "200": {
+        "value": "#fef2d3",
+        "type": "color",
+        "parent": "global/Value",
+        "description": ""
+      },
+      "300": {
+        "value": "#fde6a7",
+        "type": "color",
+        "parent": "global/Value",
+        "description": ""
+      },
+      "400": {
+        "value": "#fcd97a",
+        "type": "color",
+        "parent": "global/Value",
+        "description": ""
+      },
+      "500": {
+        "value": "#fbcc4e",
+        "type": "color",
+        "parent": "global/Value",
+        "description": ""
+      },
+      "600": {
+        "value": "#deb032",
+        "type": "color",
+        "parent": "global/Value",
+        "description": ""
+      },
+      "700": {
+        "value": "#a78425",
+        "type": "color",
+        "parent": "global/Value",
+        "description": ""
+      },
+      "800": {
+        "value": "#6f5819",
+        "type": "color",
+        "parent": "global/Value",
+        "description": ""
+      },
+      "900": {
+        "value": "#382c0c",
+        "type": "color",
+        "parent": "global/Value",
+        "description": ""
+      }
+    },
+    "orange": {
+      "50": {
+        "value": "#fffbeb",
+        "type": "color",
+        "parent": "global/Value",
+        "description": "",
+        "oldValue": "#fef9f5"
+      },
+      "100": {
+        "value": "#fef3c7",
+        "type": "color",
+        "parent": "global/Value",
+        "description": "",
+        "oldValue": "#fef3ec"
+      },
+      "200": {
+        "value": "#fde68a",
+        "type": "color",
+        "parent": "global/Value",
+        "description": "",
+        "oldValue": "#fce5d5"
+      },
+      "300": {
+        "value": "#fcd34d",
+        "type": "color",
+        "parent": "global/Value",
+        "description": "",
+        "oldValue": "#f9cbaa"
+      },
+      "400": {
+        "value": "#fbbf24",
+        "type": "color",
+        "parent": "global/Value",
+        "description": "",
+        "oldValue": "#f6b280"
+      },
+      "500": {
+        "value": "#f59e0b",
+        "type": "color",
+        "parent": "global/Value",
+        "description": "",
+        "oldValue": "#f39855"
+      },
+      "600": {
+        "value": "#d97706",
+        "type": "color",
+        "parent": "global/Value",
+        "description": "",
+        "oldValue": "#d77b39"
+      },
+      "700": {
+        "value": "#b45309",
+        "type": "color",
+        "parent": "global/Value",
+        "description": "",
+        "oldValue": "#a15d2b"
+      },
+      "800": {
+        "value": "#92400e",
+        "type": "color",
+        "parent": "global/Value",
+        "description": "",
+        "oldValue": "#6b3e1c"
+      },
+      "900": {
+        "value": "#78350f",
+        "type": "color",
+        "parent": "global/Value",
+        "description": "",
+        "oldValue": "#361f0e"
+      }
+    },
+    "red": {
+      "50": {
+        "value": "#fef2f2",
+        "type": "color",
+        "parent": "global/Value",
+        "description": "",
+        "oldValue": "#fef6f6"
+      },
+      "100": {
+        "value": "#fee2e2",
+        "type": "color",
+        "parent": "global/Value",
+        "description": "",
+        "oldValue": "#fdeded"
+      },
+      "200": {
+        "value": "#fecaca",
+        "type": "color",
+        "parent": "global/Value",
+        "description": "",
+        "oldValue": "#fbd7d7"
+      },
+      "300": {
+        "value": "#fca5a5",
+        "type": "color",
+        "parent": "global/Value",
+        "description": "",
+        "oldValue": "#f6aeae"
+      },
+      "400": {
+        "value": "#f87171",
+        "type": "color",
+        "parent": "global/Value",
+        "description": "",
+        "oldValue": "#f28181"
+      },
+      "500": {
+        "value": "#ef4444",
+        "type": "color",
+        "parent": "global/Value",
+        "description": "",
+        "oldValue": "#e75252"
+      },
+      "600": {
+        "value": "#dc2626",
+        "type": "color",
+        "parent": "global/Value",
+        "description": "",
+        "oldValue": "#b64141"
+      },
+      "700": {
+        "value": "#b91c1c",
+        "type": "color",
+        "parent": "global/Value",
+        "description": "",
+        "oldValue": "#893030"
+      },
+      "800": {
+        "value": "#991b1b",
+        "type": "color",
+        "parent": "global/Value",
+        "description": "",
+        "oldValue": "#5e2121"
+      },
+      "900": {
+        "value": "#7f1d1d",
+        "type": "color",
+        "parent": "global/Value",
+        "description": "",
+        "oldValue": "#351313"
+      }
+    }
+  },
+  "opacity": {
+    "5": {
+      "value": "0.05",
+      "type": "opacity"
+    },
+    "10": {
+      "value": "0.10",
+      "type": "opacity"
+    },
+    "25": {
+      "value": "0.25",
+      "type": "opacity"
+    },
+    "50": {
+      "value": "0.5",
+      "type": "opacity"
+    },
+    "75": {
+      "value": "0.75",
+      "type": "opacity"
+    },
+    "90": {
+      "value": "0.9",
+      "type": "opacity"
+    }
+  },
+  "border": {
+    "default": {
+      "value": {
+        "color": "{colors.content.500}",
+        "width": "1",
+        "style": "solid"
+      },
+      "type": "border"
+    }
+  }
+}

--- a/malty/theme/NewMaltyThemeProvider/tokens/helpers/semantics.json
+++ b/malty/theme/NewMaltyThemeProvider/tokens/helpers/semantics.json
@@ -1,0 +1,1235 @@
+{
+  "typography": {
+    "font": {
+      "value": "Montserrat",
+      "type": "text",
+      "parent": "semantic/malty",
+      "description": ""
+    },
+    "weight": {
+      "value": "SemiBold",
+      "type": "text",
+      "parent": "semantic/malty",
+      "oldValue": "SemiBold",
+      "description": "600"
+    }
+  },
+  "border radius": {
+    "radius": {
+      "value": "{border radius.rounded}",
+      "type": "dimension",
+      "parent": "semantic/malty",
+      "description": ""
+    }
+  },
+  "colors": {
+    "default": {
+      "content": {
+        "100": {
+          "value": "{colors.content.100}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "500": {
+          "value": "{colors.content.500}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "900": {
+          "value": "{colors.content.900}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        }
+      },
+      "primary": {
+        "50": {
+          "value": "{colors.neutral.50}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "100": {
+          "value": "{colors.neutral.100}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "200": {
+          "value": "{colors.neutral.200}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "300": {
+          "value": "{colors.neutral.300}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "400": {
+          "value": "{colors.neutral.400}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "500": {
+          "value": "{colors.neutral.500}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "600": {
+          "value": "{colors.neutral.600}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "700": {
+          "value": "{colors.neutral.700}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "800": {
+          "value": "{colors.neutral.800}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "900": {
+          "value": "{colors.neutral.900}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        }
+      },
+      "background": {
+        "primary": {
+          "static": {
+            "value": "{colors.neutral.900}",
+            "type": "color",
+            "parent": "semantic/malty",
+            "description": ""
+          },
+          "interactive--default": {
+            "value": "{colors.neutral.900}",
+            "type": "color",
+            "parent": "semantic/malty",
+            "description": ""
+          },
+          "interactive--hover": {
+            "value": "{colors.neutral.800}",
+            "type": "color",
+            "parent": "semantic/malty",
+            "description": ""
+          },
+          "interactive--pressed": {
+            "value": "{colors.neutral.700}",
+            "type": "color",
+            "parent": "semantic/malty",
+            "description": ""
+          },
+          "interactive--focus": {
+            "value": "{colors.neutral.300}",
+            "type": "color",
+            "parent": "semantic/malty",
+            "description": ""
+          },
+          "interactive--selected": {
+            "value": "{colors.neutral.600}",
+            "type": "color",
+            "parent": "semantic/malty",
+            "description": ""
+          },
+          "interactive--disabled": {
+            "value": "{colors.neutral.100}",
+            "type": "color",
+            "parent": "semantic/malty",
+            "description": ""
+          }
+        }
+      },
+      "foreground": {
+        "primary": {
+          "static": {
+            "value": "{colors.content.100}",
+            "type": "color",
+            "parent": "semantic/malty",
+            "description": ""
+          },
+          "interactive--default": {
+            "value": "{colors.content.100}",
+            "type": "color",
+            "parent": "semantic/malty",
+            "description": ""
+          },
+          "interactive--hover": {
+            "value": "{colors.content.100}",
+            "type": "color",
+            "parent": "semantic/malty",
+            "description": ""
+          },
+          "interactive--pressed": {
+            "value": "{colors.content.100}",
+            "type": "color",
+            "parent": "semantic/malty",
+            "description": ""
+          },
+          "interactive--focus": {
+            "value": "{colors.content.100}",
+            "type": "color",
+            "parent": "semantic/malty",
+            "description": ""
+          },
+          "interactive--selected": {
+            "value": "{colors.content.100}",
+            "type": "color",
+            "parent": "semantic/malty",
+            "description": ""
+          },
+          "interactive--disabled": {
+            "value": "{colors.neutral.600}",
+            "type": "color",
+            "parent": "semantic/malty",
+            "description": ""
+          }
+        },
+        "secondary": {
+          "static": {
+            "value": "{colors.neutral.900}",
+            "type": "color",
+            "parent": "semantic/malty",
+            "description": ""
+          },
+          "interactive--default": {
+            "value": "{colors.neutral.900}",
+            "type": "color",
+            "parent": "semantic/malty",
+            "description": ""
+          },
+          "interactive--hover": {
+            "value": "{colors.neutral.800}",
+            "type": "color",
+            "parent": "semantic/malty",
+            "description": ""
+          },
+          "interactive--pressed": {
+            "value": "{colors.neutral.700}",
+            "type": "color",
+            "parent": "semantic/malty",
+            "description": ""
+          },
+          "interactive--focus": {
+            "value": "{colors.neutral.500}",
+            "type": "color",
+            "parent": "semantic/malty",
+            "description": ""
+          },
+          "interactive--selected": {
+            "value": "{colors.neutral.600}",
+            "type": "color",
+            "parent": "semantic/malty",
+            "description": ""
+          },
+          "interactive--disabled": {
+            "value": "{colors.neutral.400}",
+            "type": "color",
+            "parent": "semantic/malty",
+            "description": ""
+          }
+        }
+      },
+      "error": {
+        "50": {
+          "value": "{colors.red.50}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "100": {
+          "value": "{colors.red.100}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "200": {
+          "value": "{colors.red.200}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "300": {
+          "value": "{colors.red.300}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "400": {
+          "value": "{colors.red.400}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "500": {
+          "value": "{colors.red.500}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "600": {
+          "value": "{colors.red.600}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "700": {
+          "value": "{colors.red.700}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "800": {
+          "value": "{colors.red.800}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "900": {
+          "value": "{colors.red.900}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        }
+      },
+      "warning": {
+        "50": {
+          "value": "{colors.orange.50}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "100": {
+          "value": "{colors.orange.100}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "200": {
+          "value": "{colors.orange.200}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "300": {
+          "value": "{colors.orange.300}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "400": {
+          "value": "{colors.orange.400}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "500": {
+          "value": "{colors.orange.500}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "600": {
+          "value": "{colors.orange.600}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "700": {
+          "value": "{colors.orange.700}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "800": {
+          "value": "{colors.orange.800}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "900": {
+          "value": "{colors.orange.900}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        }
+      },
+      "success": {
+        "50": {
+          "value": "{colors.green.50}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "100": {
+          "value": "{colors.green.100}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "200": {
+          "value": "{colors.green.200}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "300": {
+          "value": "{colors.green.300}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "400": {
+          "value": "{colors.green.400}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "500": {
+          "value": "{colors.green.500}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "600": {
+          "value": "{colors.green.600}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "700": {
+          "value": "{colors.green.700}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "800": {
+          "value": "{colors.green.800}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "900": {
+          "value": "{colors.green.900}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        }
+      },
+      "information": {
+        "50": {
+          "value": "{colors.blue.50}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "100": {
+          "value": "{colors.blue.100}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "200": {
+          "value": "{colors.blue.200}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "300": {
+          "value": "{colors.blue.300}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "400": {
+          "value": "{colors.blue.400}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "500": {
+          "value": "{colors.blue.500}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "600": {
+          "value": "{colors.blue.600}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "700": {
+          "value": "{colors.blue.700}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "800": {
+          "value": "{colors.blue.800}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "900": {
+          "value": "{colors.blue.900}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        }
+      }
+    },
+    "inverted": {
+      "primary": {
+        "50": {
+          "value": "{colors.neutral.50}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "100": {
+          "value": "{colors.neutral.100}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "200": {
+          "value": "{colors.neutral.200}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "300": {
+          "value": "{colors.neutral.300}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "400": {
+          "value": "{colors.neutral.400}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "500": {
+          "value": "{colors.neutral.500}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "600": {
+          "value": "{colors.neutral.600}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "700": {
+          "value": "{colors.neutral.700}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "800": {
+          "value": "{colors.neutral.800}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "900": {
+          "value": "{colors.neutral.900}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        }
+      },
+      "background": {
+        "primary": {
+          "static": {
+            "value": "{colors.content.100}",
+            "type": "color",
+            "parent": "semantic/malty",
+            "description": ""
+          },
+          "interactive--default": {
+            "value": "{colors.content.100}",
+            "type": "color",
+            "parent": "semantic/malty",
+            "description": ""
+          },
+          "interactive--hover": {
+            "value": "{colors.neutral.100}",
+            "type": "color",
+            "parent": "semantic/malty",
+            "description": ""
+          },
+          "interactive--pressed": {
+            "value": "{colors.content.100}",
+            "type": "color",
+            "parent": "semantic/malty",
+            "description": ""
+          },
+          "interactive--focus": {
+            "value": "{colors.neutral.200}",
+            "type": "color",
+            "parent": "semantic/malty",
+            "description": ""
+          },
+          "interactive--selected": {
+            "value": "{colors.neutral.200}",
+            "type": "color",
+            "parent": "semantic/malty",
+            "description": ""
+          },
+          "interactive--disabled": {
+            "value": "{colors.neutral.50}",
+            "type": "color",
+            "parent": "semantic/malty",
+            "description": ""
+          }
+        }
+      },
+      "foreground": {
+        "primary": {
+          "static": {
+            "value": "{colors.neutral.900}",
+            "type": "color",
+            "parent": "semantic/malty",
+            "description": ""
+          },
+          "interactive--default": {
+            "value": "{colors.neutral.900}",
+            "type": "color",
+            "parent": "semantic/malty",
+            "description": ""
+          },
+          "interactive--hover": {
+            "value": "{colors.neutral.700}",
+            "type": "color",
+            "parent": "semantic/malty",
+            "description": ""
+          },
+          "interactive--pressed": {
+            "value": "{colors.neutral.900}",
+            "type": "color",
+            "parent": "semantic/malty",
+            "description": ""
+          },
+          "interactive--focus": {
+            "value": "{colors.neutral.500}",
+            "type": "color",
+            "parent": "semantic/malty",
+            "description": ""
+          },
+          "interactive--selected": {
+            "value": "{colors.neutral.900}",
+            "type": "color",
+            "parent": "semantic/malty",
+            "description": ""
+          },
+          "interactive--disabled": {
+            "value": "{colors.neutral.400}",
+            "type": "color",
+            "parent": "semantic/malty",
+            "description": ""
+          }
+        },
+        "secondary": {
+          "static": {
+            "value": "{colors.content.100}",
+            "type": "color",
+            "parent": "semantic/malty",
+            "description": ""
+          },
+          "interactive--default": {
+            "value": "{colors.content.100}",
+            "type": "color",
+            "parent": "semantic/malty",
+            "description": ""
+          },
+          "interactive--hover": {
+            "value": "{colors.content.100}",
+            "type": "color",
+            "parent": "semantic/malty",
+            "description": ""
+          },
+          "interactive--pressed": {
+            "value": "{colors.content.100}",
+            "type": "color",
+            "parent": "semantic/malty",
+            "description": ""
+          },
+          "interactive--focus": {
+            "value": "{colors.content.100}",
+            "type": "color",
+            "parent": "semantic/malty",
+            "description": ""
+          },
+          "interactive--selected": {
+            "value": "{colors.content.100}",
+            "type": "color",
+            "parent": "semantic/malty",
+            "description": ""
+          },
+          "interactive--disabled": {
+            "value": "{colors.content.100}",
+            "type": "color",
+            "parent": "semantic/malty",
+            "description": ""
+          }
+        }
+      },
+      "content": {
+        "100": {
+          "value": "{colors.content.100}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "500": {
+          "value": "{colors.content.500}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "900": {
+          "value": "{colors.content.900}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        }
+      },
+      "error": {
+        "50": {
+          "value": "{colors.red.50}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "100": {
+          "value": "{colors.red.100}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "200": {
+          "value": "{colors.red.200}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "300": {
+          "value": "{colors.red.300}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "400": {
+          "value": "{colors.red.400}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "500": {
+          "value": "{colors.red.500}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "600": {
+          "value": "{colors.red.600}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "700": {
+          "value": "{colors.red.700}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "800": {
+          "value": "{colors.red.800}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "900": {
+          "value": "{colors.red.900}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        }
+      },
+      "warning": {
+        "50": {
+          "value": "{colors.orange.50}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "100": {
+          "value": "{colors.orange.100}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "200": {
+          "value": "{colors.orange.200}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "300": {
+          "value": "{colors.orange.300}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "400": {
+          "value": "{colors.orange.400}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "500": {
+          "value": "{colors.orange.500}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "600": {
+          "value": "{colors.orange.600}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "700": {
+          "value": "{colors.orange.700}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "800": {
+          "value": "{colors.orange.800}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "900": {
+          "value": "{colors.orange.900}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        }
+      },
+      "success": {
+        "50": {
+          "value": "{colors.green.50}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "100": {
+          "value": "{colors.green.100}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "200": {
+          "value": "{colors.green.200}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "300": {
+          "value": "{colors.green.300}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "400": {
+          "value": "{colors.green.400}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "500": {
+          "value": "{colors.green.500}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "600": {
+          "value": "{colors.green.600}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "700": {
+          "value": "{colors.green.700}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "800": {
+          "value": "{colors.green.800}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "900": {
+          "value": "{colors.green.900}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        }
+      },
+      "information": {
+        "50": {
+          "value": "{colors.blue.50}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "100": {
+          "value": "{colors.blue.100}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "200": {
+          "value": "{colors.blue.200}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "300": {
+          "value": "{colors.blue.300}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "400": {
+          "value": "{colors.blue.400}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "500": {
+          "value": "{colors.blue.500}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "600": {
+          "value": "{colors.blue.600}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "700": {
+          "value": "{colors.blue.700}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "800": {
+          "value": "{colors.blue.800}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        },
+        "900": {
+          "value": "{colors.blue.900}",
+          "type": "color",
+          "parent": "semantic/malty",
+          "description": ""
+        }
+      }
+    }
+  },
+  "border": {
+    "default": {
+      "value": "{colors.default.content.500}",
+      "type": "color",
+      "parent": "semantic/malty",
+      "description": ""
+    }
+  },
+  "grid": {
+    "xs": {
+      "fixed": {
+        "columns": {
+          "value": "6",
+          "type": "other"
+        },
+        "minWidth": {
+          "value": "0",
+          "type": "other"
+        },
+        "maxWidth": {
+          "value": "375",
+          "type": "other"
+        },
+        "margin": {
+          "value": "16",
+          "type": "other"
+        },
+        "gutter": {
+          "value": "16",
+          "type": "other"
+        },
+        "container": {
+          "value": "100",
+          "type": "other"
+        }
+      },
+      "fluid": {
+        "columns": {
+          "value": "6",
+          "type": "other"
+        },
+        "minWidth": {
+          "value": "0",
+          "type": "other"
+        },
+        "maxWidth": {
+          "value": "375",
+          "type": "other"
+        },
+        "margin": {
+          "value": "16",
+          "type": "other"
+        },
+        "gutter": {
+          "value": "16",
+          "type": "other"
+        },
+        "container": {
+          "value": "100",
+          "type": "other"
+        }
+      }
+    },
+    "s": {
+      "fixed": {
+        "columns": {
+          "value": "6",
+          "type": "other"
+        },
+        "minWidth": {
+          "value": "376",
+          "type": "other"
+        },
+        "maxWidth": {
+          "value": "768",
+          "type": "other"
+        },
+        "margin": {
+          "value": "16",
+          "type": "other"
+        },
+        "gutter": {
+          "value": "16",
+          "type": "other"
+        },
+        "container": {
+          "value": "100",
+          "type": "other"
+        }
+      },
+      "fluid": {
+        "columns": {
+          "value": "6",
+          "type": "other"
+        },
+        "minWidth": {
+          "value": "376",
+          "type": "other"
+        },
+        "maxWidth": {
+          "value": "376",
+          "type": "other"
+        },
+        "margin": {
+          "value": "16",
+          "type": "other"
+        },
+        "gutter": {
+          "value": "16",
+          "type": "other"
+        },
+        "container": {
+          "value": "100",
+          "type": "other"
+        }
+      }
+    },
+    "m": {
+      "fixed": {
+        "columns": {
+          "value": "12",
+          "type": "other"
+        },
+        "minWidth": {
+          "value": "769",
+          "type": "other"
+        },
+        "maxWidth": {
+          "value": "1024",
+          "type": "other"
+        },
+        "margin": {
+          "value": "24",
+          "type": "other"
+        },
+        "gutter": {
+          "value": "16",
+          "type": "other"
+        },
+        "container": {
+          "value": "100",
+          "type": "other"
+        }
+      },
+      "fluid": {
+        "columns": {
+          "value": "12",
+          "type": "other"
+        },
+        "minWidth": {
+          "value": "769",
+          "type": "other"
+        },
+        "maxWidth": {
+          "value": "1024",
+          "type": "other"
+        },
+        "margin": {
+          "value": "24",
+          "type": "other"
+        },
+        "gutter": {
+          "value": "16",
+          "type": "other"
+        },
+        "container": {
+          "value": "100",
+          "type": "other"
+        }
+      }
+    },
+    "l": {
+      "fixed": {
+        "columns": {
+          "value": "12",
+          "type": "other"
+        },
+        "minWidth": {
+          "value": "1025",
+          "type": "other"
+        },
+        "maxWidth": {
+          "value": "1440",
+          "type": "other"
+        },
+        "margin": {
+          "value": "32",
+          "type": "other"
+        },
+        "gutter": {
+          "value": "24",
+          "type": "other"
+        },
+        "container": {
+          "value": "100",
+          "type": "other"
+        }
+      },
+      "fluid": {
+        "columns": {
+          "value": "12",
+          "type": "other"
+        },
+        "minWidth": {
+          "value": "1025",
+          "type": "other"
+        },
+        "maxWidth": {
+          "value": "1440",
+          "type": "other"
+        },
+        "margin": {
+          "value": "32",
+          "type": "other"
+        },
+        "gutter": {
+          "value": "24",
+          "type": "other"
+        },
+        "container": {
+          "value": "100",
+          "type": "other"
+        }
+      }
+    },
+    "xl": {
+      "fixed": {
+        "columns": {
+          "value": "12",
+          "type": "other"
+        },
+        "minWidth": {
+          "value": "1441",
+          "type": "other"
+        },
+        "margin": {
+          "value": "32",
+          "type": "other"
+        },
+        "gutter": {
+          "value": "32",
+          "type": "other"
+        },
+        "container": {
+          "value": "1440",
+          "type": "other"
+        }
+      },
+      "fluid": {
+        "columns": {
+          "value": "12",
+          "type": "other"
+        },
+        "minWidth": {
+          "value": "1441",
+          "type": "other"
+        },
+        "margin": {
+          "value": "32",
+          "type": "other"
+        },
+        "gutter": {
+          "value": "32",
+          "type": "other"
+        },
+        "container": {
+          "value": "100",
+          "type": "other"
+        }
+      }
+    }
+  }
+}

--- a/malty/theme/NewMaltyThemeProvider/tokens/index.ts
+++ b/malty/theme/NewMaltyThemeProvider/tokens/index.ts
@@ -1,0 +1,49 @@
+import {
+  getDefaultPrimitiveTokens,
+  getDefaultSemanticTokens,
+  getGridTokens,
+  getPrimitiveBorderTokens,
+  getPrimitiveColors,
+  getSemanticColors,
+  getShadowTokens,
+  getTypographyTokens
+} from './helpers';
+import {
+  GridTokens,
+  OpacityTokens,
+  PrimitiveBorderRadiusTokens,
+  PrimitiveBorderTokens,
+  PrimitiveColorsTokens,
+  SemanticBorderRadiusTokens,
+  SemanticColorsTokens,
+  ShadowTokens,
+  SizeTokens,
+  TypographyTokens
+} from './types';
+
+const primitiveColors = getPrimitiveColors() as PrimitiveColorsTokens;
+const semanticColors = getSemanticColors(primitiveColors) as SemanticColorsTokens;
+const typography = getTypographyTokens() as TypographyTokens;
+const sizes = getDefaultPrimitiveTokens('sizes') as SizeTokens;
+const primitiveBorderRadius = getDefaultPrimitiveTokens('border radius') as PrimitiveBorderRadiusTokens;
+const semanticBorderRadius = getDefaultSemanticTokens(
+  'border radius',
+  primitiveBorderRadius
+) as SemanticBorderRadiusTokens;
+const opacity = getDefaultPrimitiveTokens('opacity') as OpacityTokens;
+const shadows = getShadowTokens() as ShadowTokens;
+const grid = getGridTokens() as GridTokens;
+const borders = getPrimitiveBorderTokens(primitiveColors) as PrimitiveBorderTokens;
+
+export {
+  primitiveColors,
+  semanticColors,
+  typography,
+  sizes,
+  primitiveBorderRadius,
+  semanticBorderRadius,
+  opacity,
+  shadows,
+  grid,
+  borders
+};

--- a/malty/theme/NewMaltyThemeProvider/tokens/types/borderRadius.types.ts
+++ b/malty/theme/NewMaltyThemeProvider/tokens/types/borderRadius.types.ts
@@ -1,0 +1,9 @@
+export type PrimitiveBorderRadiusTokens = {
+  square: string;
+  rounded: string;
+  round: string;
+};
+
+export type SemanticBorderRadiusTokens = {
+  radius: string;
+};

--- a/malty/theme/NewMaltyThemeProvider/tokens/types/borders.types.ts
+++ b/malty/theme/NewMaltyThemeProvider/tokens/types/borders.types.ts
@@ -1,0 +1,15 @@
+export type PrimitiveBorderTokens = {
+  default: BorderProps;
+};
+
+type BorderProps = {
+  style: string;
+  width: string;
+  color: string;
+};
+
+export type SemanticBorderTokens = {
+  default: {
+    color: string;
+  };
+};

--- a/malty/theme/NewMaltyThemeProvider/tokens/types/colors.types.ts
+++ b/malty/theme/NewMaltyThemeProvider/tokens/types/colors.types.ts
@@ -1,0 +1,205 @@
+export type PrimitiveColorsTokens = {
+  neutral: {
+    50: string;
+    100: string;
+    200: string;
+    300: string;
+    400: string;
+    500: string;
+    600: string;
+    700: string;
+    800: string;
+    900: string;
+  };
+  purple: {
+    50: string;
+    100: string;
+    200: string;
+    300: string;
+    400: string;
+    500: string;
+    600: string;
+    700: string;
+    800: string;
+    900: string;
+  };
+  pink: {
+    50: string;
+    100: string;
+    200: string;
+    300: string;
+    400: string;
+    500: string;
+    600: string;
+    700: string;
+    800: string;
+    900: string;
+  };
+  red: {
+    50: string;
+    100: string;
+    200: string;
+    300: string;
+    400: string;
+    500: string;
+    600: string;
+    700: string;
+    800: string;
+    900: string;
+  };
+  orange: {
+    50: string;
+    100: string;
+    200: string;
+    300: string;
+    400: string;
+    500: string;
+    600: string;
+    700: string;
+    800: string;
+    900: string;
+  };
+  yellow: {
+    50: string;
+    100: string;
+    200: string;
+    300: string;
+    400: string;
+    500: string;
+    600: string;
+    700: string;
+    800: string;
+    900: string;
+  };
+  teal: {
+    50: string;
+    100: string;
+    200: string;
+    300: string;
+    400: string;
+    500: string;
+    600: string;
+    700: string;
+    800: string;
+    900: string;
+  };
+  green: {
+    50: string;
+    100: string;
+    200: string;
+    300: string;
+    400: string;
+    500: string;
+    600: string;
+    700: string;
+    800: string;
+    900: string;
+  };
+  blue: {
+    50: string;
+    100: string;
+    200: string;
+    300: string;
+    400: string;
+    500: string;
+    600: string;
+    700: string;
+    800: string;
+    900: string;
+  };
+  content: {
+    100: string;
+    500: string;
+    900: string;
+  };
+};
+
+export type SemanticColorsTokens = {
+  default: SemanticTokensProps;
+  inverted: SemanticTokensProps;
+};
+
+type SemanticTokensProps = {
+  content: {
+    100: string;
+    500: string;
+    900: string;
+  };
+  primary: {
+    50: string;
+    100: string;
+    200: string;
+    300: string;
+    400: string;
+    500: string;
+    600: string;
+    700: string;
+    800: string;
+    900: string;
+  };
+  background: {
+    primary: InteractiveStates;
+  };
+  foreground: {
+    primary: InteractiveStates;
+    secondary: InteractiveStates;
+  };
+  error: {
+    50: string;
+    100: string;
+    200: string;
+    300: string;
+    400: string;
+    500: string;
+    600: string;
+    700: string;
+    800: string;
+    900: string;
+  };
+  warning: {
+    50: string;
+    100: string;
+    200: string;
+    300: string;
+    400: string;
+    500: string;
+    600: string;
+    700: string;
+    800: string;
+    900: string;
+  };
+  success: {
+    50: string;
+    100: string;
+    200: string;
+    300: string;
+    400: string;
+    500: string;
+    600: string;
+    700: string;
+    800: string;
+    900: string;
+  };
+  information: {
+    50: string;
+    100: string;
+    200: string;
+    300: string;
+    400: string;
+    500: string;
+    600: string;
+    700: string;
+    800: string;
+    900: string;
+  };
+};
+
+type InteractiveStates = {
+  static: string;
+  'interactive--default': string;
+  'interactive--hover': string;
+  'interactive--focus': string;
+  'interactive--selected': string;
+  'interactive--disabled': string;
+  'interactive--pressed': string;
+};

--- a/malty/theme/NewMaltyThemeProvider/tokens/types/grid.types.ts
+++ b/malty/theme/NewMaltyThemeProvider/tokens/types/grid.types.ts
@@ -1,0 +1,23 @@
+export type GridTokens = {
+  xs: GridTypes;
+  s: GridTypes;
+  m: GridTypes;
+  l: GridTypes;
+  xl: {
+    fluid: Omit<GridProps, 'maxWidth'>;
+    fixed: Omit<GridProps, 'maxWidth'>;
+  };
+};
+
+type GridProps = {
+  maxWidth: string;
+  minWidth: string;
+  columns: string;
+  gutter: string;
+  margin: string;
+};
+
+type GridTypes = {
+  fixed: GridProps;
+  fluid: GridProps;
+};

--- a/malty/theme/NewMaltyThemeProvider/tokens/types/index.ts
+++ b/malty/theme/NewMaltyThemeProvider/tokens/types/index.ts
@@ -1,0 +1,15 @@
+export type { PrimitiveBorderRadiusTokens, SemanticBorderRadiusTokens } from './borderRadius.types';
+export type { PrimitiveBorderTokens, SemanticBorderTokens } from './borders.types';
+export type { PrimitiveColorsTokens, SemanticColorsTokens } from './colors.types';
+export type { GridTokens } from './grid.types';
+export type { OpacityTokens } from './opacity.types';
+export type { ShadowTokens } from './shadows.types';
+export type {
+  AdditionalPrimitives,
+  BorderRadiusTokens,
+  ColorTokens,
+  SemanticOverrides,
+  SemanticTokens
+} from './shared.types';
+export type { SizeTokens } from './sizes.types';
+export type { TypographyTokens } from './typography.types';

--- a/malty/theme/NewMaltyThemeProvider/tokens/types/opacity.types.ts
+++ b/malty/theme/NewMaltyThemeProvider/tokens/types/opacity.types.ts
@@ -1,0 +1,5 @@
+export type OpacityTokens = {
+  s: string;
+  m: string;
+  l: string;
+};

--- a/malty/theme/NewMaltyThemeProvider/tokens/types/shadows.types.ts
+++ b/malty/theme/NewMaltyThemeProvider/tokens/types/shadows.types.ts
@@ -1,0 +1,6 @@
+export type ShadowTokens = {
+  100: string;
+  200: string;
+  300: string;
+  400: string;
+};

--- a/malty/theme/NewMaltyThemeProvider/tokens/types/shared.types.ts
+++ b/malty/theme/NewMaltyThemeProvider/tokens/types/shared.types.ts
@@ -1,0 +1,25 @@
+import { PrimitiveBorderRadiusTokens, SemanticBorderRadiusTokens } from './borderRadius.types';
+import { SemanticBorderTokens } from './borders.types';
+import { PrimitiveColorsTokens, SemanticColorsTokens } from './colors.types';
+import { SemanticTypographyTokens } from './typography.types';
+
+export type DeepPartial<T> = {
+  [P in keyof T]?: T[P] extends (infer R)[] ? DeepPartial<R>[] : T[P] extends object ? DeepPartial<T[P]> : T[P];
+};
+
+export type MakeExtendable<T extends object> = {
+  [K in keyof T]: T[K] extends object ? MakeExtendable<T[K]> : T[K];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+} & { [k: string]: any };
+
+export type SemanticTokens = {
+  colors: SemanticColorsTokens;
+  borderRadius: SemanticBorderRadiusTokens;
+  borders: SemanticBorderTokens;
+  typography: SemanticTypographyTokens;
+};
+
+export type ColorTokens = PrimitiveColorsTokens & SemanticColorsTokens;
+export type BorderRadiusTokens = PrimitiveBorderRadiusTokens & SemanticBorderRadiusTokens;
+export type SemanticOverrides = DeepPartial<SemanticTokens>;
+export type AdditionalPrimitives = DeepPartial<MakeExtendable<PrimitiveColorsTokens>>;

--- a/malty/theme/NewMaltyThemeProvider/tokens/types/sizes.types.ts
+++ b/malty/theme/NewMaltyThemeProvider/tokens/types/sizes.types.ts
@@ -1,0 +1,24 @@
+export type SizeTokens = {
+  '4xs': string;
+  '3xs': string;
+  '2xs': string;
+  xs: string;
+  s: string;
+  m: string;
+  l: string;
+  xl: string;
+  '2xl': string;
+  '3xl': string;
+  '4xl': string;
+  '5xl': string;
+  '6xl': string;
+  '7xl': string;
+  '8xl': string;
+  '9xl': string;
+  '10xl': string;
+  '11xl': string;
+  '12xl': string;
+  '13xl': string;
+  '14xl': string;
+  '15xl': string;
+};

--- a/malty/theme/NewMaltyThemeProvider/tokens/types/typography.types.ts
+++ b/malty/theme/NewMaltyThemeProvider/tokens/types/typography.types.ts
@@ -1,0 +1,76 @@
+export type TypographyTokens = {
+  body: {
+    10: Omit<FontWeightTypes, 'light' | 'light-underline'>;
+    12: Omit<FontWeightTypes, 'light' | 'light-underline'>;
+    14: Omit<FontWeightTypes, 'light' | 'light-underline'>;
+    16: Omit<FontWeightTypes, 'light' | 'light-underline'>;
+  };
+  headline: {
+    20: Omit<FontWeightTypes, 'semi-bold' | 'semi-bold-underline'>;
+    24: Omit<FontWeightTypes, 'semi-bold' | 'semi-bold-underline'>;
+    32: Omit<FontWeightTypes, 'semi-bold' | 'semi-bold-underline'>;
+    48: Omit<FontWeightTypes, 'semi-bold' | 'semi-bold-underline'>;
+  };
+  display: {
+    56: Omit<FontWeightTypes, 'semi-bold' | 'semi-bold-underline'>;
+    72: Omit<FontWeightTypes, 'semi-bold' | 'semi-bold-underline'>;
+  };
+};
+
+type FontStyles = {
+  fontFamily: string;
+  fontWeight: number;
+  lineHeight: string;
+  fontSize: string;
+  letterSpacing: string;
+  paragraphSpacing: string;
+  paragraphIndent: string;
+  textCase: string;
+  textDecoration: string;
+};
+
+type FontWeightTypes = {
+  light: FontStyles;
+  'light-underline': FontStyles;
+  regular: FontStyles;
+  'regular-underline': FontStyles;
+  bold: FontStyles;
+  'bold-underline': FontStyles;
+  'semi-bold': FontStyles;
+  'semi-bold-underline': FontStyles;
+};
+
+export type SemanticTypographyTokens = {
+  body: {
+    10: Omit<OverridableFontWeightTypes, 'light' | 'light-underline'>;
+    12: Omit<OverridableFontWeightTypes, 'light' | 'light-underline'>;
+    14: Omit<OverridableFontWeightTypes, 'light' | 'light-underline'>;
+    16: Omit<OverridableFontWeightTypes, 'light' | 'light-underline'>;
+  };
+  headline: {
+    20: Omit<OverridableFontWeightTypes, 'semi-bold' | 'semi-bold-underline'>;
+    24: Omit<OverridableFontWeightTypes, 'semi-bold' | 'semi-bold-underline'>;
+    32: Omit<OverridableFontWeightTypes, 'semi-bold' | 'semi-bold-underline'>;
+    48: Omit<OverridableFontWeightTypes, 'semi-bold' | 'semi-bold-underline'>;
+  };
+  display: {
+    56: Omit<OverridableFontWeightTypes, 'semi-bold' | 'semi-bold-underline'>;
+    72: Omit<OverridableFontWeightTypes, 'semi-bold' | 'semi-bold-underline'>;
+  };
+};
+
+type OverridableFontStyles = {
+  fontFamily: string;
+  fontWeight: number;
+};
+
+type OverridableFontWeightTypes = {
+  light: OverridableFontStyles;
+  'light-underline': OverridableFontStyles;
+  regular: OverridableFontStyles;
+  'regular-underline': OverridableFontStyles;
+  bold: OverridableFontStyles;
+  'bold-underline': OverridableFontStyles;
+  'semi-bold': OverridableFontStyles;
+  'semi-bold-underline': OverridableFontStyles;
+};


### PR DESCRIPTION
# What

- First release of the new version of the tokens;
- The application of these new tokens to the existing components will be made gradually, that's why we have now 2 Malty Theme Providers. This is a temporary solution to have both logics running. The old Malty Theme Provider will be deprecated after we finish the tokens application in all components.

<!-- Describe the technical "why" behind your changes -->

## Code Quality Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have updated storybook (if appropriate)
- [ ] I have ran `yarn set-peer-dep` when adding an icon as a dependency of another component (if appropriate) [read more](https://carlsberggbs.atlassian.net/wiki/spaces/DSM/pages/4697162121/Components+as+peer+dependency)

## Jira Card

<!-- if no card is associated, remove the line bellow and add "Not Applicable" -->

Not Applicable
